### PR TITLE
modify tfs_upstream directives

### DIFF
--- a/ReadMe.markdown
+++ b/ReadMe.markdown
@@ -22,43 +22,106 @@
 指令
 ====
 
-tfs_upstream
+server
 ------------
 
-**Syntax**： *tfs_upstream tfs_ups_addr*
+**Syntax**： *server address*
+
+**Default**： *none*
+
+**Context**： *tfs_upstream*
+
+指定后端TFS服务器的地址，当指令<i>type</i>为<i>on</i>时为RcServer的地址，否则为NameServer的地址。此指令必须配置。例如:
+
+	server 10.0.0.1:8108;
+
+type
+----------------
+
+**Syntax**： *type [name_server | rc_server]*
+
+**Default**： *rc_server*
+
+**Context**： *tfs_upstream*
+
+设置server类型，类型只能为name\_server或者rc\_server，如果为name\_server,则指令<i>server</i>指定的地址为NameServer的地址，如果为rc\_server,则为RcServer的地址。开启此指令需配置RcServer。如需使用自定义文件名功能请设置类型为rc\_server，使用自定义文件名功能需额外配置MetaServer和RootServer。
+
+zone
+--------------
+
+**Syntax**： *zone size=num*
+
+**Default**： *none*
+
+**Context**： *tfs_upstream*
+
+配置TFS应用在RcServer的配置信息。若开启RcServer（配置了<i>type rc\_server</i>），则必须配置此指令。配置此指令会在共享内存中缓存TFS应用在RcServer的配置信息，并可以通过指令<i>poll_rcs</i>来和RcServer进行keepalive以保证应用的配置信息的及时更新。例如：
+
+	zone size=128M;
+
+poll\_rcs
+--------------
+
+**Syntax**： *poll_rcs lock_file=/path/to/file interval=time enable=[1 | 0]*
+
+**Default**： *none*
+
+**Context**： *tfs_upstream*
+
+配置TFS应用和RcServer的keepalive，应用可通过此功能来和RcServer定期交互，以及时更新其配置信息。若开启RcServer功能（配置了<i>type rc_server</i>），则必须配置此指令。例如：
+
+	poll_rcs lock_file=/path/to/nginx/logs/lk.file interval=10s enable=1;
+
+net\_device
+----------------
+
+**Syntax**： *net_device interface*
+
+**Default**： *none*
+
+**Context**： *tfs_upstream*
+
+配置TFS模块使用的网卡。若开启RcServer功能（配置了<i>type rc_server</i>），则必须配置此指令。例如：
+
+	net_device eth0;
+    
+tfs\_upstream
+----------------
+
+**Syntax**： *tfs\_upstream name {...}*
 
 **Default**： *none*
 
 **Context**： *http*
 
-指定后端TFS服务器的地址，当指令<i>tfs_enable_rcs</i>为<i>on</i>时为RcServer的地址，否则为NameServer的地址。此指令必须配置。例如:
+配置TFS模块使用的网卡。若开启RcServer功能（配置了<i>type rc_server</i>），则必须配置此指令。例如：
 
-	tfs_upstream 10.0.0.1:8108;
+    tfs_upstream tfs {
+        server 127.0.0.1:6100;
+        type rc_server;
+        zone size=128M;
+        net_device eth0;
+        poll_rcs lock_file=/logs/lk.file interval=10s enable=1;
+    }
 
-tfs\_enable\_rcs
-----------------
-
-**Syntax**： *tfs_enable_rcs [on | off]*
-
-**Default**： *off*
-
-**Context**： *http, server*
-
-是否开启RcServer功能，此指令必须配置。如开启，则指令<i>tfs_upstream</i>指定的地址为RcServer的地址，否则为NameServer的地址。开启此指令需配置RcServer。如需使用自定义文件名功能请开启此指令，使用自定义文件名功能需额外配置MetaServer和RootServer。
-
+   
 tfs_pass
 --------
 
-**Syntax**： *tfs_pass enable=[1 | 0]*
+**Syntax**： *tfs_pass name*
 
 **Default**： *none*
 
 **Context**： *location*
 
-是否打开TFS模块功能，此指令为关键指令，决定请求是否由TFS模块处理，必须配置。需配置在“/” location。例如：
+是否打开TFS模块功能，此指令为关键指令，决定请求是否由TFS模块处理，必须配置。需要注意，这里不支持直接写ip地址或者域名，这里只支持指令<i>tfs_upstream name {...} </i>配置的upstream,并且必须以 tfs:// 开头。例如：
+
+
+	tfs_upstream tfs {
+    };
 
 	location / {
-		tfs_pass enable=1;
+		tfs_pass tfs://tfs;
 	}
 
 tfs_keepalive
@@ -87,49 +150,10 @@ tfs\_block\_cache\_zone
 
 	tfs_block_cache_zone size=256M;
 
-tfs\_rcs\_zone
---------------
-
-**Syntax**： *tfs_rcs_zone size=num*
-
-**Default**： *none*
-
-**Context**： *http*
-
-配置TFS应用在RcServer的配置信息。若开启RcServer功能（配置了<i>tfs_enable_rcs on</i>），则必须配置此指令。配置此指令会在共享内存中缓存TFS应用在RcServer的配置信息，并可以通过指令<i>tfs_poll_rcs</i>来和RcServer进行keepalive以保证应用的配置信息的及时更新。例如：
-
-	tfs_rcs_zone size=128M;
-
-tfs\_poll\_rcs
---------------
-
-**Syntax**： *tfs_poll_rcs lock_file=/path/to/file interval=time enable=[1 | 0]*
-
-**Default**： *none*
-
-**Context**： *http*
-
-配置TFS应用和RcServer的keepalive，应用可通过此功能来和RcServer定期交互，以及时更新其配置信息。若开启RcServer功能（配置了<i>tfs_enable_rcs on</i>），则必须配置此指令。例如：
-
-	tfs_poll_rcs lock_file=/path/to/nginx/logs/lk.file interval=10s enable=1;
-
-tfs\_net\_device
+tfs\_log
 ----------------
 
-**Syntax**： *tfs_net_device interface*
-
-**Default**： *none*
-
-**Context**： *http, server*
-
-配置TFS模块使用的网卡。若开启RcServer功能（配置了<i>tfs_enable_rcs on</i>），则必须配置此指令。例如：
-
-	tfs_net_device eth0;
-
-tfs\_tackle\_log
-----------------
-
-**Syntax**： *tfs_tackle_log path*
+**Syntax**： *tfs_log path*
 
 **Default**： *none*
 
@@ -137,7 +161,7 @@ tfs\_tackle\_log
 
 是否进行TFS访问记录。配置此指令会以固定格式将访问TFS的请求记录到指定log中，以便进行分析。具体格式参见代码。例如：
 
-	tfs_tackle_log "pipe:/usr/sbin/cronolog -p 30min /path/to/nginx/logs/cronolog/%Y/%m/%Y-%m-%d-%H-%M-tfs_access.log";
+	tfs_log "pipe:/usr/sbin/cronolog -p 30min /path/to/nginx/logs/cronolog/%Y/%m/%Y-%m-%d-%H-%M-tfs_access.log";
 
 注：cronolog支持依赖于tengine提供的扩展的日志模块。
 

--- a/example.conf
+++ b/example.conf
@@ -33,11 +33,16 @@ http {
     gzip  off;
 
     # ns_addr
-    tfs_upstream 10.0.0.1:8108;
-    # rcs_addr
-    #tfs_upstream 10.0.0.1:7200;
+    tfs_upstream tfs {
+        server 10.0.0.1:8108;
+        # rcs_addr
+        #server 10.0.0.1:7200;
+        type name_server;
+        net_device eth0;
+        #zone size=128M;
+    };
 
-    #tfs_rcs_zone size=128M;
+
     tfs_block_cache_zone size=256M;
 
     tfs_send_timeout 3s;
@@ -56,14 +61,10 @@ http {
         #access_log "pipe:/usr/sbin/cronolog /path/to/nginx/logs/cronolog/%Y/%m/%Y-%m-%d-access.log";
 
         tfs_keepalive max_cached=100 bucket_count=10;
-        #tfs_tackle_log "pipe:/usr/sbin/cronolog -p 30min /path/to/nginx/logs/cronolog/%Y/%m/%Y-%m-%d-%H-%M-tfs_access.log";
-        tfs_net_device eth0;
-
-        tfs_enable_rcs off;
+        #tfs_log "pipe:/usr/sbin/cronolog -p 30min /path/to/nginx/logs/cronolog/%Y/%m/%Y-%m-%d-%H-%M-tfs_access.log";
 
         location / {
-            tfs_pass enable=1;
+            tfs_pass tfs://tfs;
         }
-
     }
 }

--- a/ngx_http_tfs.h
+++ b/ngx_http_tfs.h
@@ -95,6 +95,28 @@ typedef struct {
 
 
 typedef struct {
+    ngx_str_t                                lock_file;
+    ngx_msec_t                               rcs_interval;
+
+    ngx_flag_t                               rcs_kp_enable;
+    ngx_shm_zone_t                          *rcs_shm_zone;
+    ngx_http_tfs_rc_ctx_t                   *rc_ctx;
+
+    /* upstream name and port */
+    in_port_t                                port;
+    ngx_str_t                                host;
+    ngx_addr_t                              *ups_addr;
+
+    struct sockaddr_in                       local_addr;
+    u_char                                   local_addr_text[NGX_INET_ADDRSTRLEN];
+
+    ngx_flag_t                               enable_rcs;
+
+    unsigned                                 used:1;
+} ngx_http_tfs_upstream_t;
+
+
+typedef struct {
     ngx_msec_t                       timeout;
 
     size_t                           max_temp_file_size;
@@ -102,16 +124,14 @@ typedef struct {
 
     size_t                           busy_buffers_size_conf;
 
-    size_t                           rcs_zone_size;
-
     uint64_t                         meta_root_server;
     ngx_http_tfs_meta_table_t        meta_server_table;
+
+    ngx_http_tfs_upstream_t         *upstream;
 } ngx_http_tfs_loc_conf_t;
 
 
 typedef struct {
-    struct sockaddr_in               local_addr;
-    u_char                           local_addr_text[NGX_INET_ADDRSTRLEN];
 
     ngx_log_t                       *log;
 } ngx_http_tfs_srv_conf_t;
@@ -130,23 +150,17 @@ typedef struct {
     size_t                                   body_buffer_size;
     size_t                                   busy_buffers_size;
 
-    ngx_str_t                                lock_file;
-    ngx_msec_t                               rcs_interval;
-
-    ngx_shm_zone_t                          *rcs_shm_zone;
     ngx_shm_zone_t                          *block_cache_shm_zone;
 
     ngx_flag_t                               enable_remote_block_cache;
-    ngx_http_tfs_rc_ctx_t                   *rc_ctx;
     ngx_http_tfs_tair_instance_t             remote_block_cache_instance;
     ngx_http_tfs_local_block_cache_ctx_t    *local_block_cache_ctx;
 
-    ngx_flag_t                               rcs_kp_enable;
     ngx_http_connection_pool_t              *conn_pool;
 
-    ngx_addr_t                              *ups_addr;
-    ngx_flag_t                               enable_rcs;
     uint32_t                                 cluster_id;
+
+    ngx_array_t                              upstreams;
 } ngx_http_tfs_main_conf_t;
 
 

--- a/ngx_http_tfs_data_server_message.c
+++ b/ngx_http_tfs_data_server_message.c
@@ -372,7 +372,6 @@ ngx_http_tfs_create_write_message(ngx_http_tfs_t *t,
     p += sizeof(uint64_t);
     /* lease id */
     *((uint64_t *) p) = block_info->lease_id;
-    p += sizeof(uint64_t);
     b->last += size;
 
     req->length = segment_data->oper_size;

--- a/ngx_http_tfs_meta_server_message.c
+++ b/ngx_http_tfs_meta_server_message.c
@@ -289,12 +289,10 @@ ngx_http_tfs_create_read_meta_message(ngx_http_tfs_t *t, int64_t req_offset, uin
 
     if (req_frag_count > max_frag_count) {
         *((uint64_t *) p) = (max_frag_count - 1) * NGX_HTTP_TFS_MAX_FRAGMENT_SIZE;
-        p += sizeof(uint64_t);
         t->has_split_frag = NGX_HTTP_TFS_YES;
 
     } else {
         *((uint64_t *) p) = req_size;
-        p += sizeof(uint64_t);
         t->has_split_frag = NGX_HTTP_TFS_NO;
     }
 
@@ -437,7 +435,6 @@ ngx_http_tfs_create_ls_message(ngx_http_tfs_t *t)
     p += sizeof(uint8_t);
 
     *((uint64_t *)p) = t->loc_conf->meta_server_table.version;
-    p += sizeof(uint64_t);
 
     req->header.crc = ngx_http_tfs_crc(NGX_HTTP_TFS_PACKET_FLAG,
                                        (const char *) (&req->header + 1),
@@ -554,7 +551,6 @@ ngx_http_tfs_parse_read_meta_message(ngx_http_tfs_t *t)
     p = tp->body_buffer.pos + sizeof(ngx_http_tfs_ms_read_response_t);
     fmi = (ngx_http_tfs_meta_frag_meta_info_t *) p;
 
-    curr_length = 0;
     for (i = 0; i < count; i++, fmi++) {
         t->file.segment_data[i].segment_info.block_id = fmi->block_id;
         t->file.segment_data[i].segment_info.file_id = fmi->file_id;

--- a/ngx_http_tfs_module.c
+++ b/ngx_http_tfs_module.c
@@ -16,6 +16,13 @@
 #define NGX_HTTP_TFS_RCS_ZONE_NAME "tfs_module_rcs_zone"
 #define NGX_HTTP_TFS_BLOCK_CACHE_ZONE_NAME "tfs_module_block_cache_zone"
 
+#define NGX_HTTP_TFS_UPSTREAM_CREATE           1
+#define NGX_HTTP_TFS_UPSTREAM_FIND             2
+
+#define NGX_HTTP_TFS_RCSERVER_TYPE             "rc_server"
+#define NGX_HTTP_TFS_NAMESERVER_TYPE           "name_server"
+
+
 static void *ngx_http_tfs_create_main_conf(ngx_conf_t *cf);
 static char *ngx_http_tfs_init_main_conf(ngx_conf_t *cf, void *conf);
 
@@ -33,20 +40,21 @@ static char *ngx_http_tfs_upstream(ngx_conf_t *cf, ngx_command_t *cmd, void *con
 static char *ngx_http_tfs_pass(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 
-static char *ngx_http_tfs_tackle_log(ngx_conf_t *cf, ngx_command_t *cmd,
+static char *ngx_http_tfs_log(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 
-static char *ngx_http_tfs_net_device(ngx_conf_t *cf, ngx_command_t *cmd,
-    void *conf);
+static char *ngx_http_tfs_net_device(ngx_conf_t *cf, ngx_http_tfs_upstream_t *tu);
 
 static char *ngx_http_tfs_lowat_check(ngx_conf_t *cf, void *post, void *data);
 static void ngx_http_tfs_read_body_handler(ngx_http_request_t *r);
 static char *ngx_http_tfs_keepalive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 
-static char *ngx_http_tfs_poll_rcs(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static char *ngx_http_tfs_poll_rcs(ngx_conf_t *cf, ngx_http_tfs_upstream_t *tu);
 
-static char *ngx_http_tfs_rcs_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static char *ngx_http_tfs_rcs_zone(ngx_conf_t *cf, ngx_http_tfs_upstream_t *tu);
 static char *ngx_http_tfs_block_cache_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+
+static char *ngx_http_tfs_upstream_parse(ngx_conf_t *cf, ngx_command_t *dummy, void *conf);
 
 /* rc server keepalive */
 static ngx_int_t ngx_http_tfs_check_init_worker(ngx_cycle_t *cycle);
@@ -63,7 +71,7 @@ static ngx_conf_post_t  ngx_http_tfs_lowat_post =
 static ngx_command_t  ngx_http_tfs_commands[] = {
 
     { ngx_string("tfs_upstream"),
-      NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+      NGX_HTTP_MAIN_CONF|NGX_CONF_BLOCK|NGX_CONF_TAKE1,
       ngx_http_tfs_upstream,
       0,
       0,
@@ -76,13 +84,6 @@ static ngx_command_t  ngx_http_tfs_commands[] = {
       0,
       NULL },
 
-    { ngx_string("tfs_net_device"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
-      ngx_http_tfs_net_device,
-      NGX_HTTP_SRV_CONF_OFFSET,
-      0,
-      NULL },
-
     { ngx_string("tfs_keepalive"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE2,
       ngx_http_tfs_keepalive,
@@ -90,16 +91,9 @@ static ngx_command_t  ngx_http_tfs_commands[] = {
       0,
       NULL },
 
-    { ngx_string("tfs_poll_rcs"),
-      NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE3,
-      ngx_http_tfs_poll_rcs,
-      0,
-      0,
-      NULL },
-
-    { ngx_string("tfs_tackle_log"),
+    { ngx_string("tfs_log"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE12,
-      ngx_http_tfs_tackle_log,
+      ngx_http_tfs_log,
       NGX_HTTP_SRV_CONF_OFFSET,
       0,
       NULL },
@@ -153,13 +147,6 @@ static ngx_command_t  ngx_http_tfs_commands[] = {
       offsetof(ngx_http_tfs_main_conf_t, body_buffer_size),
       NULL },
 
-    { ngx_string("tfs_rcs_zone"),
-      NGX_HTTP_MAIN_CONF|NGX_CONF_1MORE,
-      ngx_http_tfs_rcs_zone,
-      0,
-      0,
-      NULL },
-
     { ngx_string("tfs_block_cache_zone"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_1MORE,
       ngx_http_tfs_block_cache_zone,
@@ -172,13 +159,6 @@ static ngx_command_t  ngx_http_tfs_commands[] = {
       ngx_conf_set_flag_slot,
       0,
       offsetof(ngx_http_tfs_main_conf_t, enable_remote_block_cache),
-      NULL },
-
-    { ngx_string("tfs_enable_rcs"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
-      ngx_conf_set_flag_slot,
-      0,
-      offsetof(ngx_http_tfs_main_conf_t, enable_rcs),
       NULL },
 
       ngx_null_command
@@ -266,7 +246,7 @@ ngx_http_tfs_handler(ngx_http_request_t *r)
 
     t->header_only = r->header_only;
 
-    if (!tmcf->enable_rcs && t->r_ctx.version == 2) {
+    if (!t->loc_conf->upstream->enable_rcs && t->r_ctx.version == 2) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "custom file requires tfs_enable_rcs on,"
                       " and make sure you have MetaServer and RootServer!");
@@ -311,34 +291,193 @@ ngx_http_tfs_handler(ngx_http_request_t *r)
 }
 
 
+ngx_http_tfs_upstream_t *
+ngx_http_tfs_upstream_add(ngx_conf_t *cf, ngx_url_t *u, ngx_uint_t flags)
+{
+    ngx_uint_t                      i;
+    ngx_http_tfs_upstream_t        *tu, **tup;
+    ngx_http_tfs_main_conf_t       *tmcf;
+
+    if (!(flags & NGX_HTTP_TFS_UPSTREAM_CREATE)) {
+
+        if (ngx_parse_url(cf->pool, u) != NGX_OK) {
+            if (u->err) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "%s in tfs upstream \"%V\"", u->err, &u->url);
+            }
+
+            return NULL;
+        }
+    }
+
+    tmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_tfs_module);
+
+    tup = tmcf->upstreams.elts;
+
+    for (i = 0; i < tmcf->upstreams.nelts; i++)  {
+
+        if (tup[i]->host.len != u->host.len
+            || ngx_strncasecmp(tup[i]->host.data, u->host.data, u->host.len)
+               != 0)
+        {
+            continue;
+        }
+
+        if (flags & NGX_HTTP_TFS_UPSTREAM_CREATE)
+        {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "duplicate tfs upstream \"%V\"", &u->host);
+            return NULL;
+        }
+
+        return tup[i];
+    }
+
+    if (flags & NGX_HTTP_TFS_UPSTREAM_FIND) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           " host not found in tfs upstream \"%V\"", &u->url);
+        return NULL;
+    }
+
+    /* NGX_HTTP_TFS_UPSTREAM_CREATE */
+
+    tu = ngx_pcalloc(cf->pool, sizeof(ngx_http_tfs_upstream_t));
+    if (tu == NULL) {
+        return NULL;
+    }
+
+    tu->host = u->host;
+
+    tup = ngx_array_push(&tmcf->upstreams);
+    if (tup == NULL) {
+        return NULL;
+    }
+
+    *tup = tu;
+
+    return tu;
+}
+
+
 static char *
 ngx_http_tfs_upstream(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-    ngx_http_tfs_main_conf_t       *tmcf = conf;
-
+    char                           *rv;
     ngx_url_t                       u;
-    ngx_str_t                      *value, *server_addr;
-
-    value = cf->args->elts;
-    server_addr = &value[1];
+    ngx_str_t                      *value;
+    ngx_conf_t                      pcf;
+    ngx_http_tfs_upstream_t        *tu;
 
     ngx_memzero(&u, sizeof(ngx_url_t));
 
-    u.url.len = server_addr->len;
-    u.url.data = server_addr->data;
+    value = cf->args->elts;
+    u.host = value[1];
+    u.no_resolve = 1;
 
-    if (ngx_parse_url(cf->pool, &u) != NGX_OK) {
-        if (u.err) {
-            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                "%s in tfs \"%V\"", u.err, &u.url);
-        }
-
+    tu = ngx_http_tfs_upstream_add(cf, &u, NGX_HTTP_TFS_UPSTREAM_CREATE);
+    if (tu == NULL) {
         return NGX_CONF_ERROR;
     }
 
-    tmcf->ups_addr = u.addrs;
+    /* parse inside tfs_upstream{} */
 
-    return NGX_CONF_OK;
+    pcf = *cf;
+    cf->ctx = tu;
+    cf->handler = ngx_http_tfs_upstream_parse;
+    cf->handler_conf = conf;
+
+    rv = ngx_conf_parse(cf, NULL);
+
+    *cf = pcf;
+
+    if (rv != NGX_CONF_OK) {
+        return rv;
+    }
+
+    if (tu->ups_addr == NULL) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "no servers are inside tfs upstream");
+        return NGX_CONF_ERROR;
+    }
+
+    return rv;
+}
+
+
+static char *
+ngx_http_tfs_upstream_parse(ngx_conf_t *cf, ngx_command_t *dummy, void *conf)
+{
+    ngx_url_t                       u;
+    ngx_str_t                      *value, *server_addr;
+    ngx_http_tfs_upstream_t        *tu;
+
+    tu = cf->ctx;
+
+    value = cf->args->elts;
+
+    if (ngx_strcmp(value[0].data, "server") == 0) {
+
+        value = cf->args->elts;
+        server_addr = &value[1];
+
+        ngx_memzero(&u, sizeof(ngx_url_t));
+
+        u.url.len = server_addr->len;
+        u.url.data = server_addr->data;
+
+        if (ngx_parse_url(cf->pool, &u) != NGX_OK) {
+            if (u.err) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "%s in tfs \"%V\"", u.err, &u.url);
+            }
+
+            return NGX_CONF_ERROR;
+        }
+
+        tu->ups_addr = u.addrs;
+
+        return NGX_CONF_OK;
+    }
+
+    if (ngx_strcmp(value[0].data, "type") == 0) {
+
+        if (cf->args->nelts != 2) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "invalid number of arguments in \"%s\" directive", &value[0]);
+            return NGX_CONF_ERROR;
+        }
+
+        if (ngx_strcmp(value[1].data, NGX_HTTP_TFS_NAMESERVER_TYPE) == 0) {
+            tu->enable_rcs = NGX_HTTP_TFS_NO;
+
+        } else if (ngx_strcmp(value[1].data, NGX_HTTP_TFS_RCSERVER_TYPE) == 0) {
+            tu->enable_rcs = NGX_HTTP_TFS_YES;
+
+        } else {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "invalid parameter \"%V\"", &value[1]);
+            return NGX_CONF_ERROR;
+        }
+
+        return NGX_CONF_OK;
+    }
+
+    if (ngx_strcmp(value[0].data, "zone") == 0) {
+        return ngx_http_tfs_rcs_zone(cf, tu);
+    }
+
+    if (ngx_strcmp(value[0].data, "net_device") == 0) {
+        return ngx_http_tfs_net_device(cf, tu);
+    }
+
+    if (ngx_strcmp(value[0].data, "poll_rcs") == 0) {
+        return ngx_http_tfs_poll_rcs(cf, tu);
+    }
+
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                       "invalid parameter \"%V\"", &value[0]);
+
+    return NGX_CONF_ERROR;
 }
 
 
@@ -405,10 +544,8 @@ invalid:
 
 
 static char *
-ngx_http_tfs_poll_rcs(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ngx_http_tfs_poll_rcs(ngx_conf_t *cf, ngx_http_tfs_upstream_t *tu)
 {
-    ngx_http_tfs_main_conf_t  *tmcf = conf;
-
     ngx_msec_t               interval;
     ngx_str_t               *value, s;
     ngx_uint_t               i;
@@ -425,7 +562,7 @@ ngx_http_tfs_poll_rcs(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 goto rcs_timers_error;
             }
 
-            tmcf->lock_file = s;
+            tu->lock_file = s;
             continue;
         }
 
@@ -439,7 +576,7 @@ ngx_http_tfs_poll_rcs(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 return "invalid value";
             }
 
-            tmcf->rcs_interval = interval;
+            tu->rcs_interval = interval;
             continue;
         }
 
@@ -452,21 +589,21 @@ ngx_http_tfs_poll_rcs(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 goto rcs_timers_error;
             }
 
-            tmcf->rcs_kp_enable = rcs_kp_enable;
+            tu->rcs_kp_enable = rcs_kp_enable;
             continue;
         }
 
         goto rcs_timers_error;
     }
 
-    if (tmcf->lock_file.len == 0) {
+    if (tu->lock_file.len == 0) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                            "tfs_poll directive must have lock file");
         return NGX_CONF_ERROR;
     }
 
-    if (tmcf->rcs_interval < NGX_HTTP_TFS_MIN_TIMER_DELAY) {
-        tmcf->rcs_interval = NGX_HTTP_TFS_MIN_TIMER_DELAY;
+    if (tu->rcs_interval < NGX_HTTP_TFS_MIN_TIMER_DELAY) {
+        tu->rcs_interval = NGX_HTTP_TFS_MIN_TIMER_DELAY;
         ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
                            "tfs_poll interval is small, so reset this value to 1000");
     }
@@ -476,33 +613,31 @@ ngx_http_tfs_poll_rcs(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 rcs_timers_error:
     ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                        "invalid value \"%V\" in \"%V\" directive",
-                       &value[i], &cmd->name);
+                       &value[i], &value[0]);
     return NGX_CONF_ERROR;
 }
 
 
 static char *
-ngx_http_tfs_net_device(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ngx_http_tfs_net_device(ngx_conf_t *cf, ngx_http_tfs_upstream_t *tu)
 {
-    ngx_http_tfs_srv_conf_t  *tscf = conf;
-
     ngx_int_t                       rc;
     ngx_str_t                      *value;
 
     value = cf->args->elts;
-    rc = ngx_http_tfs_get_local_ip(value[1], &tscf->local_addr);
+    rc = ngx_http_tfs_get_local_ip(value[1], &tu->local_addr);
     if (rc == NGX_ERROR) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "device is invalid(%V)", &value[1]);
         return NGX_CONF_ERROR;
     }
 
-    ngx_inet_ntop(AF_INET, &tscf->local_addr.sin_addr, tscf->local_addr_text, NGX_INET_ADDRSTRLEN);
+    ngx_inet_ntop(AF_INET, &tu->local_addr.sin_addr, tu->local_addr_text, NGX_INET_ADDRSTRLEN);
     return NGX_CONF_OK;
 }
 
 
 static char *
-ngx_http_tfs_tackle_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ngx_http_tfs_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
     ngx_http_tfs_srv_conf_t                *tscf = conf;
     ngx_str_t                              *value;
@@ -567,11 +702,16 @@ ngx_http_tfs_create_main_conf(ngx_conf_t *cf)
     conf->buffer_size = NGX_CONF_UNSET_SIZE;
     conf->body_buffer_size = NGX_CONF_UNSET_SIZE;
 
-    conf->rcs_interval = NGX_CONF_UNSET;
     conf->conn_pool = NGX_CONF_UNSET_PTR;
 
     conf->enable_remote_block_cache = NGX_CONF_UNSET;
-    conf->enable_rcs = NGX_CONF_UNSET;
+
+    if (ngx_array_init(&conf->upstreams, cf->pool, 4,
+                       sizeof(ngx_http_tfs_upstream_t *))
+        != NGX_OK)
+    {
+        return NULL;
+    }
 
     return conf;
 }
@@ -610,10 +750,6 @@ ngx_http_tfs_init_main_conf(ngx_conf_t *cf, void *conf)
         tmcf->body_buffer_size = (size_t) ngx_pagesize * 2;
     }
 
-    if (tmcf->enable_rcs == NGX_CONF_UNSET) {
-        tmcf->enable_rcs = NGX_HTTP_TFS_NO;
-    }
-
     return NGX_CONF_OK;
 }
 
@@ -642,26 +778,38 @@ static char *ngx_http_tfs_merge_loc_conf(ngx_conf_t *cf,
 static char *
 ngx_http_tfs_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-    ngx_int_t                       enable;
+    ngx_int_t                       add;
     ngx_str_t                      *value, s;
+    ngx_url_t                       u;
     ngx_http_tfs_main_conf_t       *tmcf;
-    ngx_http_tfs_srv_conf_t        *tscf;
+    ngx_http_tfs_loc_conf_t        *tlcf;
     ngx_http_core_loc_conf_t       *clcf;
 
     value = cf->args->elts;
-    if (ngx_strncmp(value[1].data, "enable=", 7) == 0) {
-        s.len = value[1].len - 7;
-        s.data = value[1].data + 7;
-
-        enable = ngx_atoi(s.data, s.len);
-        if (!enable) {
-            return NGX_CONF_OK;
-        }
-    }
 
     clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
-    tscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_tfs_module);
     tmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_tfs_module);
+    tlcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_tfs_module);
+
+    if (ngx_strncasecmp(value[1].data, (u_char *) "tfs://", 6) == 0) {
+        add = 6;
+
+    } else {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "invalid URL prefix in tfs_pass");
+        return NGX_CONF_ERROR;
+    }
+
+    ngx_memzero(&u, sizeof(ngx_url_t));
+
+    u.url.len = value[1].len - add;
+    u.url.data = value[1].data + add;
+    u.uri_part = 1;
+    u.no_resolve = 1;
+
+    tlcf->upstream = ngx_http_tfs_upstream_add(cf, &u, NGX_HTTP_TFS_UPSTREAM_FIND);
+    if (tlcf->upstream == NULL) {
+        return NGX_CONF_ERROR;
+    }
 
     clcf->handler = ngx_http_tfs_handler;
 
@@ -669,14 +817,8 @@ ngx_http_tfs_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         clcf->auto_redirect = 1;
     }
 
-    if (tmcf->enable_rcs == NGX_CONF_UNSET) {
-        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                           "in tfs module must assign enable rcs, use directives \"tfs_enable_rcs\" ");
-        return NGX_CONF_ERROR;
-    }
-
-    if (tmcf->enable_rcs) {
-        if (tscf->local_addr_text[0] == '\0') {
+    if (tlcf->upstream->enable_rcs) {
+        if (tlcf->upstream->local_addr_text[0] == '\0') {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                "in tfs module must assign net device name, use directives \"tfs_net_device\" ");
             return NGX_CONF_ERROR;
@@ -685,9 +827,9 @@ ngx_http_tfs_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         s.data = (u_char *) NGX_HTTP_TFS_RCS_ZONE_NAME;
         s.len = sizeof(NGX_HTTP_TFS_RCS_ZONE_NAME) - 1;
 
-        tmcf->rcs_shm_zone = ngx_shared_memory_add(cf, &s, 0,
-                                                  &ngx_http_tfs_module);
-        if (tmcf->rcs_shm_zone == NULL) {
+        tlcf->upstream->rcs_shm_zone = ngx_shared_memory_add(cf, &s, 0,
+                                                             &ngx_http_tfs_module);
+        if (tlcf->upstream->rcs_shm_zone == NULL) {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                "in tfs module must assign rcs shm zone, use directives \"tfs_rcs_zone\" ");
             return NGX_CONF_ERROR;
@@ -699,7 +841,7 @@ ngx_http_tfs_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         s.len = sizeof(NGX_HTTP_TFS_BLOCK_CACHE_ZONE_NAME) - 1;
 
         tmcf->block_cache_shm_zone = ngx_shared_memory_add(cf, &s, 0,
-                                                  &ngx_http_tfs_module);
+                                                           &ngx_http_tfs_module);
         if (tmcf->block_cache_shm_zone == NULL) {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                "in tfs module must assign block cache shm zone,"\
@@ -707,6 +849,8 @@ ngx_http_tfs_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             return NGX_CONF_ERROR;
         }
     }
+
+    tlcf->upstream->used = 1;
 
     return NGX_CONF_OK;
 }
@@ -742,9 +886,8 @@ ngx_http_tfs_lowat_check(ngx_conf_t *cf, void *post, void *data)
 
 
 static char *
-ngx_http_tfs_rcs_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ngx_http_tfs_rcs_zone(ngx_conf_t *cf, ngx_http_tfs_upstream_t *tu)
 {
-    ngx_http_tfs_main_conf_t        *tmcf = conf;
     size_t                           size;
     ngx_str_t                       *value, s, name;
     ngx_uint_t                       i;
@@ -775,7 +918,7 @@ ngx_http_tfs_rcs_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     if (size == 0) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                            "\"%V\" must have \"size\" parameter",
-                           &cmd->name);
+                           &value[0]);
         return NGX_CONF_ERROR;
     }
 
@@ -796,7 +939,7 @@ ngx_http_tfs_rcs_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     shm_zone->init = ngx_http_tfs_rc_server_init_zone;
     shm_zone->data = ctx;
 
-    tmcf->rc_ctx = ctx;
+    tu->rc_ctx = ctx;
 
     return NGX_CONF_OK;
 }
@@ -939,30 +1082,48 @@ ngx_http_tfs_module_init(ngx_cycle_t *cycle)
         return NGX_ERROR;
     }
 
-    if (tmcf->enable_rcs == NGX_HTTP_TFS_NO) {
-        return NGX_OK;
-    }
-
-    return ngx_http_tfs_timers_init(cycle, tmcf->lock_file.data);
+    return NGX_OK;
 }
 
 
 static ngx_int_t
 ngx_http_tfs_check_init_worker(ngx_cycle_t *cycle)
 {
+    ngx_uint_t                      i;
+    ngx_http_tfs_upstream_t       **tup;
     ngx_http_tfs_main_conf_t       *tmcf;
+    ngx_http_tfs_timers_data_t     *data;
+
     /* rc keepalive */
     tmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_tfs_module);
     if (tmcf == NULL) {
         return NGX_ERROR;
     }
 
-    if (tmcf->enable_rcs == NGX_HTTP_TFS_NO) {
-        return NGX_OK;
-    }
+    tup = tmcf->upstreams.elts;
 
-    if (tmcf->rcs_kp_enable) {
-        return ngx_http_tfs_add_rcs_timers(cycle, tmcf);
+    for (i = 0; i < tmcf->upstreams.nelts; i++) {
+        if (!tup[i]->enable_rcs
+            || !tup[i]->rcs_kp_enable
+            || !tup[i]->used)
+        {
+            return NGX_OK;
+        }
+
+        data = ngx_pcalloc(cycle->pool, sizeof(ngx_http_tfs_timers_data_t));
+        if (data == NULL) {
+            return NGX_ERROR;
+        }
+
+        data->main_conf = tmcf;
+        data->upstream = tup[i];
+        if ((data->lock = ngx_http_tfs_timers_init(cycle, tup[i]->lock_file.data)) == NULL) {
+            return NGX_ERROR;
+        }
+
+        if (ngx_http_tfs_add_rcs_timers(cycle, data) == NGX_ERROR) {
+            return NGX_ERROR;
+        }
     }
 
     return NGX_OK;

--- a/ngx_http_tfs_peer_connection.c
+++ b/ngx_http_tfs_peer_connection.c
@@ -29,9 +29,9 @@ ngx_http_tfs_peer_init(ngx_http_tfs_t *t)
     }
 
     /* rc server */
-    if (t->main_conf->enable_rcs) {
-        t->tfs_peer_servers[NGX_HTTP_TFS_RC_SERVER].peer.sockaddr = t->main_conf->ups_addr->sockaddr;
-        t->tfs_peer_servers[NGX_HTTP_TFS_RC_SERVER].peer.socklen = t->main_conf->ups_addr->socklen;
+    if (t->loc_conf->upstream->enable_rcs) {
+        t->tfs_peer_servers[NGX_HTTP_TFS_RC_SERVER].peer.sockaddr = t->loc_conf->upstream->ups_addr->sockaddr;
+        t->tfs_peer_servers[NGX_HTTP_TFS_RC_SERVER].peer.socklen = t->loc_conf->upstream->ups_addr->socklen;
         t->tfs_peer_servers[NGX_HTTP_TFS_RC_SERVER].peer.log = t->log;
         t->tfs_peer_servers[NGX_HTTP_TFS_RC_SERVER].peer.name = &rcs_name;
         t->tfs_peer_servers[NGX_HTTP_TFS_RC_SERVER].peer.data = conn_pool;
@@ -43,8 +43,8 @@ ngx_http_tfs_peer_init(ngx_http_tfs_t *t)
                     ntohs(((struct sockaddr_in*)(t->tfs_peer_servers[NGX_HTTP_TFS_RC_SERVER].peer.sockaddr))->sin_port));
 
     } else {
-        t->tfs_peer_servers[NGX_HTTP_TFS_NAME_SERVER].peer.sockaddr = t->main_conf->ups_addr->sockaddr;
-        t->tfs_peer_servers[NGX_HTTP_TFS_NAME_SERVER].peer.socklen = t->main_conf->ups_addr->socklen;
+        t->tfs_peer_servers[NGX_HTTP_TFS_NAME_SERVER].peer.sockaddr = t->loc_conf->upstream->ups_addr->sockaddr;
+        t->tfs_peer_servers[NGX_HTTP_TFS_NAME_SERVER].peer.socklen = t->loc_conf->upstream->ups_addr->socklen;
         ngx_sprintf(t->tfs_peer_servers[NGX_HTTP_TFS_NAME_SERVER].peer_addr_text, "%s:%d",
                     inet_ntoa(((struct sockaddr_in*)(t->tfs_peer_servers[NGX_HTTP_TFS_NAME_SERVER].peer.sockaddr))->sin_addr),
                     ntohs(((struct sockaddr_in*)(t->tfs_peer_servers[NGX_HTTP_TFS_NAME_SERVER].peer.sockaddr))->sin_port));

--- a/ngx_http_tfs_raw_fsname.c
+++ b/ngx_http_tfs_raw_fsname.c
@@ -127,9 +127,7 @@ ngx_http_tfs_raw_fsname_encode(u_char *input, u_char *output)
     uint32_t             value;
     ngx_uint_t           i, k;
 
-    i = 0;
     k = 0;
-    value = 0;
 
     if (input != NULL && output != NULL) {
         xor_mask(input, NGX_HTTP_TFS_FILE_NAME_EXCEPT_SUFFIX_LEN, buffer);
@@ -152,7 +150,6 @@ ngx_http_tfs_raw_fsname_decode(u_char *input, u_char *output)
     ngx_uint_t           i, k;
 
     k = 0;
-    value = 0;
 
     if (input != NULL && output != NULL) {
         for (i = 0; i < NGX_HTTP_TFS_FILE_NAME_LEN - 2; i += 4) {

--- a/ngx_http_tfs_remote_block_cache.c
+++ b/ngx_http_tfs_remote_block_cache.c
@@ -195,7 +195,7 @@ ngx_http_tfs_remote_block_cache_remove(ngx_http_tfs_remote_block_cache_ctx_t *ct
         return;
     }
 
-    rc = ngx_http_tfs_tair_delete_helper(ctx->tair_instance,
+    (void) ngx_http_tfs_tair_delete_helper(ctx->tair_instance,
                                          tmp_pool, log,
                                          &tair_keys,
                                          ngx_http_tfs_remote_block_cache_dummy_handler,

--- a/ngx_http_tfs_server_handler.c
+++ b/ngx_http_tfs_server_handler.c
@@ -443,7 +443,7 @@ ngx_http_tfs_process_rcs(ngx_http_tfs_t *t)
 
     tp = t->tfs_peer;
     b = &tp->body_buffer;
-    rc_ctx = t->main_conf->rc_ctx;
+    rc_ctx = t->loc_conf->upstream->rc_ctx;
 
     rc = ngx_http_tfs_rc_server_parse_message(t);
 
@@ -550,7 +550,7 @@ ngx_http_tfs_process_ns(ngx_http_tfs_t *t)
         switch(t->state) {
         case NGX_HTTP_TFS_STATE_WRITE_CLUSTER_ID_NS:
             /* save cluster id */
-            if (t->main_conf->enable_rcs) {
+            if (t->loc_conf->upstream->enable_rcs) {
                 rc_info = t->rc_info_node;
                 logical_cluster = &rc_info->logical_clusters[t->logical_cluster_index];
                 physical_cluster = &logical_cluster->rw_clusters[t->rw_cluster_index];
@@ -840,14 +840,12 @@ ngx_http_tfs_process_ds(ngx_http_tfs_t *t)
     ngx_buf_t                                *b;
     ngx_chain_t                              *cl, **ll;
     ngx_http_request_t                       *r;
-    ngx_peer_connection_t                    *p;
     ngx_http_tfs_header_t                    *header;
     ngx_http_tfs_segment_data_t              *segment_data;
     ngx_http_tfs_peer_connection_t           *tp;
 
     header = (ngx_http_tfs_header_t *) t->header;
     tp = t->tfs_peer;
-    p = &tp->peer;
     b = &tp->body_buffer;
 
     body_len = header->len;
@@ -1165,13 +1163,11 @@ ngx_http_tfs_process_ds_read(ngx_http_tfs_t *t)
     size_t                                    size;
     ngx_int_t                                 rc;
     ngx_buf_t                                *b;
-    ngx_peer_connection_t                    *p;
     ngx_http_tfs_segment_data_t              *segment_data;
     ngx_http_tfs_peer_connection_t           *tp;
     ngx_http_tfs_logical_cluster_t           *logical_cluster;
 
     tp = t->tfs_peer;
-    p = &tp->peer;
     b = &tp->body_buffer;
 
     size = ngx_buf_size(b);

--- a/ngx_http_tfs_timers.c
+++ b/ngx_http_tfs_timers.c
@@ -11,20 +11,14 @@
 static void ngx_http_tfs_timeout_handler(ngx_event_t *event);
 
 
-static ngx_atomic_t         *ngx_http_tfs_kp_mutex_ptr;
-static ngx_shmtx_t           ngx_http_tfs_kp_mutex;
-
-
-ngx_int_t
-ngx_http_tfs_timers_init(ngx_cycle_t *cycle, u_char *lock_file)
+ngx_http_tfs_timers_lock_t *
+ngx_http_tfs_timers_init(ngx_cycle_t *cycle,
+    u_char *lock_file)
 {
-    u_char                  *shared;
-    size_t                   size;
-    ngx_shm_t                shm;
-
-    if (ngx_http_tfs_kp_mutex_ptr) {
-        return NGX_OK;
-    }
+    u_char                       *shared;
+    size_t                        size;
+    ngx_shm_t                     shm;
+    ngx_http_tfs_timers_lock_t   *lock;
 
     /* cl should be equal or bigger than cache line size */
 
@@ -36,37 +30,42 @@ ngx_http_tfs_timers_init(ngx_cycle_t *cycle, u_char *lock_file)
     shm.log = cycle->log;
 
     if (ngx_shm_alloc(&shm) != NGX_OK) {
-        return NGX_ERROR;
+        return NULL;
     }
 
     shared = shm.addr;
 
-    ngx_http_tfs_kp_mutex_ptr = (ngx_atomic_t *) shared;
-    ngx_http_tfs_kp_mutex.spin = (ngx_uint_t) -1;
+    lock = ngx_palloc(cycle->pool, sizeof(ngx_http_tfs_timers_lock_t));
+    if (lock == NULL) {
+        return NULL;
+    }
+
+    lock->ngx_http_tfs_kp_mutex_ptr = (ngx_atomic_t *) shared;
+    lock->ngx_http_tfs_kp_mutex.spin = (ngx_uint_t) -1;
 
 #if defined(nginx_version) && (nginx_version > 1001008)
 
-    if (ngx_shmtx_create(&ngx_http_tfs_kp_mutex, (ngx_shmtx_sh_t *) shared, lock_file)
+    if (ngx_shmtx_create(&lock->ngx_http_tfs_kp_mutex, (ngx_shmtx_sh_t *) shared, lock_file)
         != NGX_OK)
     {
-        return NGX_ERROR;
+        return NULL;
     }
 
 #else
 
-    if (ngx_shmtx_create(&ngx_http_tfs_kp_mutex, shared, lock_file)
+    if (ngx_shmtx_create(&lock->ngx_http_tfs_kp_mutex, shared, lock_file)
         != NGX_OK)
     {
-        return NGX_ERROR;
+        return NULL;
     }
 #endif
 
-    return NGX_OK;
+    return lock;
 }
 
 
 ngx_int_t
-ngx_http_tfs_add_rcs_timers(ngx_cycle_t *cycle, ngx_http_tfs_main_conf_t *tmcf)
+ngx_http_tfs_add_rcs_timers(ngx_cycle_t *cycle, ngx_http_tfs_timers_data_t *data)
 {
     ngx_event_t                      *ev;
 
@@ -79,10 +78,10 @@ ngx_http_tfs_add_rcs_timers(ngx_cycle_t *cycle, ngx_http_tfs_main_conf_t *tmcf)
 
     ev->handler = ngx_http_tfs_timeout_handler;
     ev->log = cycle->log;
-    ev->data = tmcf;
+    ev->data = data;
     ev->timer_set = 0;
 
-    ngx_add_timer(ev, tmcf->rcs_interval);
+    ngx_add_timer(ev, data->upstream->rcs_interval);
 
     return NGX_OK;
 }
@@ -92,14 +91,14 @@ ngx_int_t
 ngx_http_tfs_timers_finalize_request_handler(ngx_http_tfs_t *t)
 {
     ngx_event_t                   *event;
-    ngx_http_tfs_main_conf_t      *tmcf;
+    ngx_http_tfs_timers_data_t    *data;
 
     event = t->finalize_data;
-    tmcf = event->data;
+    data = event->data;
 
     ngx_destroy_pool(t->pool);
-    ngx_shmtx_unlock(&ngx_http_tfs_kp_mutex);
-    ngx_add_timer(event, tmcf->rcs_interval);
+    ngx_shmtx_unlock(&data->lock->ngx_http_tfs_kp_mutex);
+    ngx_add_timer(event, data->upstream->rcs_interval);
     return NGX_OK;
 }
 
@@ -111,34 +110,34 @@ ngx_http_tfs_timeout_handler(ngx_event_t *event)
     ngx_pool_t                       *pool;
     ngx_http_tfs_t                   *t;
     ngx_http_request_t               *r;
-    ngx_http_tfs_main_conf_t         *tmcf;
+    ngx_http_tfs_timers_data_t       *data;
 
-    if (ngx_shmtx_trylock(&ngx_http_tfs_kp_mutex)) {
-        tmcf = event->data;
-        if (ngx_queue_empty(&tmcf->rc_ctx->sh->kp_queue)) {
+    data = event->data;
+    if (ngx_shmtx_trylock(&data->lock->ngx_http_tfs_kp_mutex)) {
+        if (ngx_queue_empty(&data->upstream->rc_ctx->sh->kp_queue)) {
             ngx_log_debug0(NGX_LOG_DEBUG_EVENT, event->log, 0, "empty rc keepalive queue");
-            ngx_shmtx_unlock(&ngx_http_tfs_kp_mutex);
-            ngx_add_timer(event, tmcf->rcs_interval);
+            ngx_shmtx_unlock(&data->lock->ngx_http_tfs_kp_mutex);
+            ngx_add_timer(event, data->upstream->rcs_interval);
             return;
         }
 
         pool = ngx_create_pool(8192, event->log);
         if (pool == NULL) {
-            ngx_shmtx_unlock(&ngx_http_tfs_kp_mutex);
+            ngx_shmtx_unlock(&data->lock->ngx_http_tfs_kp_mutex);
             return;
         }
 
         /* fake ngx_http_request_t */
         r = ngx_pcalloc(pool, sizeof(ngx_http_request_t));
         if (r == NULL) {
-            ngx_shmtx_unlock(&ngx_http_tfs_kp_mutex);
+            ngx_shmtx_unlock(&data->lock->ngx_http_tfs_kp_mutex);
             return;
         }
 
         r->pool = pool;
         r->connection = ngx_pcalloc(pool, sizeof(ngx_connection_t));
         if (r->connection == NULL) {
-            ngx_shmtx_unlock(&ngx_http_tfs_kp_mutex);
+            ngx_shmtx_unlock(&data->lock->ngx_http_tfs_kp_mutex);
             return;
         }
         r->connection->log = event->log;
@@ -146,7 +145,7 @@ ngx_http_tfs_timeout_handler(ngx_event_t *event)
 
         t = ngx_pcalloc(pool, sizeof(ngx_http_tfs_t));
         if (t == NULL) {
-            ngx_shmtx_unlock(&ngx_http_tfs_kp_mutex);
+            ngx_shmtx_unlock(&data->lock->ngx_http_tfs_kp_mutex);
             return;
         }
 
@@ -158,12 +157,18 @@ ngx_http_tfs_timeout_handler(ngx_event_t *event)
 
         t->r_ctx.action.code = NGX_HTTP_TFS_ACTION_KEEPALIVE;
         t->r_ctx.version = 1;
-        t->main_conf = tmcf;
+        t->loc_conf = ngx_pcalloc(pool, sizeof(ngx_http_tfs_loc_conf_t));
+        if (t->loc_conf == NULL) {
+            ngx_shmtx_unlock(&data->lock->ngx_http_tfs_kp_mutex);
+            return;
+        }
+        t->loc_conf->upstream = data->upstream;
+        t->main_conf = data->main_conf;
 
         rc = ngx_http_tfs_init(t);
         if (rc == NGX_ERROR) {
             ngx_destroy_pool(pool);
-            ngx_shmtx_unlock(&ngx_http_tfs_kp_mutex);
+            ngx_shmtx_unlock(&data->lock->ngx_http_tfs_kp_mutex);
         }
 
     } else {

--- a/ngx_http_tfs_timers.h
+++ b/ngx_http_tfs_timers.h
@@ -14,8 +14,22 @@
 #include <ngx_http_tfs.h>
 
 
-ngx_int_t ngx_http_tfs_add_rcs_timers(ngx_cycle_t *cycle, ngx_http_tfs_main_conf_t *tmcf);
-ngx_int_t ngx_http_tfs_timers_init(ngx_cycle_t *cycle, u_char *lock_file);
+typedef struct {
+    ngx_atomic_t                   *ngx_http_tfs_kp_mutex_ptr;
+    ngx_shmtx_t                     ngx_http_tfs_kp_mutex;
+} ngx_http_tfs_timers_lock_t;
+
+
+typedef struct {
+    ngx_http_tfs_main_conf_t       *main_conf;
+    ngx_http_tfs_upstream_t        *upstream;
+    ngx_http_tfs_timers_lock_t     *lock;
+} ngx_http_tfs_timers_data_t;
+
+ngx_int_t  ngx_http_tfs_add_rcs_timers(ngx_cycle_t *cycle,
+    ngx_http_tfs_timers_data_t *data);
+ngx_http_tfs_timers_lock_t *ngx_http_tfs_timers_init(ngx_cycle_t *cycle,
+    u_char *lock_file);
 
 
 #endif  /* _NGX_HTTP_TFS_TIMERS_H_INCLUDED_ */

--- a/ngx_tfs_common.c
+++ b/ngx_tfs_common.c
@@ -351,7 +351,6 @@ ngx_http_tfs_raw_fsname_hash(const u_char *str, const int32_t len)
     int32_t h, i;
 
     h = 0;
-    i = 0;
 
     if (str == NULL || len <=0) {
         return 0;


### PR DESCRIPTION
1 delete some dead code.
2 fix some code style.
3 modify tfs_upstream directives and document.

tfs_upstream example:

```
tfs_upstream tfs {
    server 127.0.0.1:6100;
    type rc_server;
    zone size=128M;
    net_device eth0;
    poll_rcs lock_file=/logs/lk.file interval=10s enable=1;
}

location / {
    tfs_pass tfs://tfs;
}
```
