### PR TITLE
some bugfix

### DIFF
--- a/src/ngx_http_tfs_rc_server_message.c
+++ b/src/ngx_http_tfs_rc_server_message.c
@@ -466,9 +466,9 @@ ngx_http_tfs_parse_rc_info(ngx_http_tfs_rcs_info_t *rc_info_node,
             }
             ngx_memcpy(physical_cluster->cluster_id_text.data, p,
                        physical_cluster->cluster_id_text.len);
+            p += physical_cluster->cluster_id_text.len + 1;
             /* this cluster id need get from ns */
             physical_cluster->cluster_id = 0;
-            p += physical_cluster->cluster_id_text.len + 1;
 
             /* name server vip */
             len = *((uint32_t *) p);

--- a/src/ngx_http_tfs_remote_block_cache.c
+++ b/src/ngx_http_tfs_remote_block_cache.c
@@ -102,6 +102,7 @@ ngx_http_tfs_remote_block_cache_get_handler(ngx_http_tair_key_value_t *kv,
                 t->state += 1;
 
                 segment_data->cache_hit = NGX_HTTP_TFS_REMOTE_BLOCK_CACHE;
+                segment_data->block_info_src = NGX_HTTP_TFS_FROM_CACHE;
 
                 /* select data server */
                 addr = ngx_http_tfs_select_data_server(t, segment_data);

--- a/src/ngx_http_tfs_server_handler.c
+++ b/src/ngx_http_tfs_server_handler.c
@@ -142,6 +142,7 @@ ngx_http_tfs_process_ms(ngx_http_tfs_t *t)
                 }
                 t->last_dir_level = 0;
                 t->dir_lens[0] = t->last_file_path.len;
+                t->orig_action = t->r_ctx.action.code;
 
             } else {
                 parent_dir_len = ngx_http_tfs_get_parent_dir(&t->last_file_path,
@@ -150,7 +151,6 @@ ngx_http_tfs_process_ms(ngx_http_tfs_t *t)
             t->last_dir_level++;
             t->dir_lens[t->last_dir_level] = parent_dir_len;
             t->last_file_path.len = t->dir_lens[t->last_dir_level];
-            t->orig_action = t->r_ctx.action.code;
             /* temporarily modify */
             t->r_ctx.action.code = NGX_HTTP_TFS_ACTION_CREATE_DIR;
             return NGX_OK;
@@ -778,7 +778,7 @@ ngx_http_tfs_reset_segment_data(ngx_http_tfs_t *t)
     segment_data = &t->file.segment_data[t->file.segment_index];
     for (i = 0; i < block_count; i++, segment_data++) {
         segment_data->cache_hit = NGX_HTTP_TFS_NO_BLOCK_CACHE;
-        segment_data->block_info_src = NGX_HTTP_TFS_FROM_CACHE;
+        segment_data->block_info_src = NGX_HTTP_TFS_FROM_NONE;
         segment_data->block_info.ds_addrs = NULL;
         segment_data->ds_retry = 0;
         segment_data->ds_index = 0;

--- a/src/ngx_tfs_common.c
+++ b/src/ngx_tfs_common.c
@@ -799,6 +799,8 @@ ngx_http_tfs_alloc_st(ngx_http_tfs_t *t)
     ngx_memcpy(&st->tfs_peer_servers[NGX_HTTP_TFS_DATA_SERVER],
                &t->tfs_peer_servers[NGX_HTTP_TFS_DATA_SERVER],
                sizeof(ngx_http_tfs_peer_connection_t));
+    st->tfs_peer_servers[NGX_HTTP_TFS_DATA_SERVER].peer.connection = NULL;
+
     b = &st->tfs_peer_servers[NGX_HTTP_TFS_DATA_SERVER].body_buffer;
     if (t->r_ctx.action.code == NGX_HTTP_TFS_ACTION_WRITE_FILE) {
         b->start = NULL;


### PR DESCRIPTION
1. 修复自定义文件一些操作递归创建父目录时如果创建两级以上父目录会将原来的行为变成创建目录的bug
2. 修复在初次并发处理自定义文件名的请求时可能在连接rootserver时core的bug
3. 增加一些错误日志.
4. 读小文件时若远程block cache命中时没有设置某个状态位，导致如果远程block cache是脏cache的时候不会重试从ns获取block info
