### PR TITLE
整理代码风格并修复若干bug

### DIFF
--- a/ReadMe.markdown
+++ b/ReadMe.markdown
@@ -30,7 +30,7 @@
             rcs_interface eth0;
             rcs_heartbeat lock_file=/logs/lk.file interval=10s;
         }
-        
+
         server {
               listen       7500;
               server_name  localhost;
@@ -109,7 +109,7 @@ rcs\_interface
 配置TFS模块使用的网卡。若开启RcServer功能（配置了<i>type rcs</i>），则必须配置此指令。例如：
 
 	rcs_interface eth0;
-    
+
 tfs\_upstream
 ----------------
 
@@ -129,7 +129,7 @@ tfs\_upstream
         rcs_heartbeat lock_file=/logs/lk.file interval=10s;
     }
 
-   
+
 tfs_pass
 --------
 

--- a/src/ngx_http_connection_pool.c
+++ b/src/ngx_http_connection_pool.c
@@ -21,9 +21,9 @@ ngx_http_connection_pool_t *
 ngx_http_connection_pool_init(ngx_pool_t *pool, ngx_uint_t max_cached,
     ngx_uint_t bucket_count)
 {
-    ngx_uint_t                                      j, k;
-    ngx_http_connection_pool_t                     *conn_pool;
-    ngx_http_connection_pool_elt_t                 *cached;
+    ngx_uint_t                      j, k;
+    ngx_http_connection_pool_t     *conn_pool;
+    ngx_http_connection_pool_elt_t *cached;
 
     conn_pool = ngx_pcalloc(pool, sizeof(ngx_http_connection_pool_t));
     if (conn_pool == NULL) {
@@ -66,12 +66,12 @@ ngx_http_connection_pool_init(ngx_pool_t *pool, ngx_uint_t max_cached,
 ngx_int_t
 ngx_http_connection_pool_get(ngx_peer_connection_t *pc, void *data)
 {
-    u_char                            pc_addr[32] = {'\0'};
-    ngx_uint_t                        bucket_id, hash;
-    ngx_queue_t                      *q, *cache, *free;
-    ngx_connection_t                 *c;
-    ngx_http_connection_pool_t       *p;
-    ngx_http_connection_pool_elt_t   *item;
+    u_char                         pc_addr[32] = {'\0'};
+    ngx_uint_t                     bucket_id, hash;
+    ngx_queue_t                    *q, *cache, *free;
+    ngx_connection_t               *c;
+    ngx_http_connection_pool_t     *p;
+    ngx_http_connection_pool_elt_t *item;
 
     p = data;
 
@@ -79,8 +79,7 @@ ngx_http_connection_pool_get(ngx_peer_connection_t *pc, void *data)
     p->count--;
 #endif
 
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                   "get keepalive peer");
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, pc->log, 0, "get keepalive peer");
 
     p->failed = 0;
 
@@ -133,15 +132,14 @@ void
 ngx_http_connection_pool_free(ngx_peer_connection_t *pc,
     void *data, ngx_uint_t state)
 {
-    ngx_http_connection_pool_t        *p = data;
-    ngx_http_connection_pool_elt_t    *item;
+    ngx_http_connection_pool_t     *p = data;
+    ngx_http_connection_pool_elt_t *item;
 
-    ngx_uint_t                         hash, bucket_id;
-    ngx_queue_t                       *q, *cache, *free;
-    ngx_connection_t                  *c;
+    ngx_uint_t         hash, bucket_id;
+    ngx_queue_t       *q, *cache, *free;
+    ngx_connection_t  *c;
 
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                   "free keepalive peer");
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, pc->log, 0, "free keepalive peer");
 
     /* remember failed state - peer.free() may be called more than once */
 
@@ -171,6 +169,7 @@ ngx_http_connection_pool_free(ngx_peer_connection_t *pc,
 #if (NGX_DEBUG)
     p->count++;
 #endif
+
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                    "free keepalive peer: saving connection %p", c);
 
@@ -231,14 +230,13 @@ ngx_http_connection_pool_free(ngx_peer_connection_t *pc,
 static void
 ngx_http_connection_pool_close_handler(ngx_event_t *ev)
 {
-    ngx_http_connection_pool_elt_t     *item;
+    ngx_http_connection_pool_elt_t  *item;
 
     int                n;
     char               buf[1];
     ngx_connection_t  *c;
 
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ev->log, 0,
-                   "keepalive close handler");
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ev->log, 0, "keepalive close handler");
 
     c = ev->data;
 
@@ -276,7 +274,6 @@ close:
 static void
 ngx_http_connection_pool_close(ngx_connection_t *c)
 {
-
 #if (NGX_HTTP_SSL)
 
     if (c->ssl) {
@@ -299,8 +296,7 @@ ngx_http_connection_pool_close(ngx_connection_t *c)
 static void
 ngx_http_connection_pool_dummy_handler(ngx_event_t *ev)
 {
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ev->log, 0,
-                   "keepalive dummy handler");
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ev->log, 0, "keepalive dummy handler");
 }
 
 #if (NGX_DEBUG)

--- a/src/ngx_http_connection_pool.h
+++ b/src/ngx_http_connection_pool.h
@@ -33,12 +33,13 @@ struct ngx_http_connection_pool_s {
 
     ngx_uint_t               failed;       /* unsigned:1 */
     ngx_pool_t              *pool;
+
 #if (NGX_DEBUG)
     ngx_int_t                count;        /* check get&free op pairs */
 #endif
 
-    ngx_event_get_peer_pt              get_peer;
-    ngx_event_free_peer_pt             free_peer;
+    ngx_event_get_peer_pt    get_peer;
+    ngx_event_free_peer_pt   free_peer;
 };
 
 
@@ -49,5 +50,6 @@ ngx_http_connection_pool_t *ngx_http_connection_pool_init(ngx_pool_t *pool,
 void ngx_http_connection_pool_check(ngx_http_connection_pool_t *coon_pool,
     ngx_log_t *log);
 #endif
+
 
 #endif  /* _NGX_HTTP_CONNECTION_POOL_H_INCLUDED_ */

--- a/src/ngx_http_tfs.c
+++ b/src/ngx_http_tfs.c
@@ -4,8 +4,8 @@
  */
 
 
-#include <ngx_http_tfs.h>
 #include <nginx.h>
+#include <ngx_http_tfs.h>
 #include <ngx_http_tfs_errno.h>
 #include <ngx_http_tfs_duplicate.h>
 #include <ngx_http_tfs_root_server_message.h>
@@ -26,7 +26,6 @@ static ngx_str_t ms_name = ngx_string("meta server");
 
 
 static void ngx_http_tfs_event_handler(ngx_event_t *ev);
-
 
 static void ngx_http_tfs_process_buf_overflow(ngx_http_request_t *r,
     ngx_http_tfs_t *t);
@@ -57,12 +56,12 @@ extern ngx_module_t  ngx_http_tfs_module;
 ngx_int_t
 ngx_http_tfs_init(ngx_http_tfs_t *t)
 {
-    ngx_int_t                                 rc;
-    ngx_http_request_t                       *r;
-    ngx_http_tfs_rc_ctx_t                    *rc_ctx;
-    ngx_http_tfs_rcs_info_t                  *rc_info;
-    ngx_http_tfs_upstream_t                  *upstream;
-    ngx_http_core_loc_conf_t                 *clcf;
+    ngx_int_t                  rc;
+    ngx_http_request_t        *r;
+    ngx_http_tfs_rc_ctx_t     *rc_ctx;
+    ngx_http_tfs_rcs_info_t   *rc_info;
+    ngx_http_tfs_upstream_t   *upstream;
+    ngx_http_core_loc_conf_t  *clcf;
 
     t->read_event_handler = ngx_http_tfs_read_handler;
     t->write_event_handler = ngx_http_tfs_send_handler;
@@ -110,6 +109,7 @@ ngx_http_tfs_init(ngx_http_tfs_t *t)
     }
 
     if (t->r_ctx.action.code != NGX_HTTP_TFS_ACTION_KEEPALIVE) {
+
         if (!upstream->enable_rcs) {
             switch(t->r_ctx.action.code) {
             case NGX_HTTP_TFS_ACTION_REMOVE_FILE:
@@ -185,7 +185,7 @@ ngx_http_tfs_init(ngx_http_tfs_t *t)
 
                 } else {
                     /* set oper size && offset,
-                     large file must read the whole meta segment */
+                     * large file must read the whole meta segment */
                     if (t->is_large_file) {
                         t->is_process_meta_seg = NGX_HTTP_TFS_YES;
                         t->file.file_offset = 0;
@@ -224,12 +224,15 @@ ngx_http_tfs_init(ngx_http_tfs_t *t)
                     return NGX_OK;
                 }
 
-                // TODO: use fine granularity mutex(per rc_info_node mutex)
-                //ngx_shmtx_lock(&rc_ctx->shpool->mutex);
+                /* TODO: use fine granularity mutex(per rc_info_node mutex) */
                 rc = ngx_http_tfs_misc_ctx_init(t, rc_info);
-                //ngx_shmtx_unlock(&rc_ctx->shpool->mutex);
-                /* wait for tair callback */
                 if (rc == NGX_DECLINED) {
+                    if (t->decline_handler) {
+                        rc = t->decline_handler(t);
+                        if (rc == NGX_ERROR) {
+                            return rc;
+                        }
+                    }
                     return NGX_OK;
                 }
 
@@ -242,8 +245,8 @@ ngx_http_tfs_init(ngx_http_tfs_t *t)
 
     t->tfs_peer = ngx_http_tfs_select_peer(t);
     if (t->tfs_peer == NULL) {
-        ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                      "tfs select peer failed");
+        ngx_log_error(NGX_LOG_ERR, t->log, 0, "tfs select peer failed");
+
         return NGX_ERROR;
     }
 
@@ -257,20 +260,30 @@ ngx_http_tfs_init(ngx_http_tfs_t *t)
 
 
 ngx_int_t
-ngx_http_tfs_lookup_block_cache(ngx_http_tfs_t *t,
-    ngx_http_tfs_segment_data_t *segment_data)
+ngx_http_tfs_lookup_block_cache(ngx_http_tfs_t *t)
 {
-    ngx_int_t                              rc;
-    ngx_http_tfs_inet_t                   *addr;
-    ngx_http_tfs_block_cache_key_t         key;
-    ngx_http_tfs_block_cache_value_t       value;
+    ngx_int_t                         rc;
+    ngx_http_tfs_inet_t              *addr;
+    ngx_http_tfs_segment_data_t      *segment_data;
+    ngx_http_tfs_block_cache_key_t    key;
+    ngx_http_tfs_block_cache_value_t  value;
 
+    segment_data = &t->file.segment_data[t->file.segment_index];
     key.ns_addr = *((uint64_t*)(&t->name_server_addr));
     key.block_id = segment_data->segment_info.block_id;
 
     rc = ngx_http_tfs_block_cache_lookup(&t->block_cache_ctx, t->pool, t->log,
                                          &key, &value);
-    if (rc == NGX_OK) {
+
+    switch (rc) {
+    case NGX_DECLINED:
+        /* remote cache handler will deal */
+        if (t->block_cache_ctx.use_cache & NGX_HTTP_TFS_REMOTE_BLOCK_CACHE) {
+            return NGX_DECLINED;
+        }
+        break;
+    case NGX_OK:
+        /* local cache hit */
         segment_data->cache_hit = NGX_HTTP_TFS_LOCAL_BLOCK_CACHE;
         segment_data->block_info_src = NGX_HTTP_TFS_FROM_CACHE;
 
@@ -278,19 +291,27 @@ ngx_http_tfs_lookup_block_cache(ngx_http_tfs_t *t,
         segment_data->block_info.ds_addrs = (ngx_http_tfs_inet_t *)
                                              value.ds_addrs;
 
-        /* skip GET_BLK_INFO state */
-        t->state += 1;
-
         addr = ngx_http_tfs_select_data_server(t, segment_data);
         if (addr == NULL) {
-            t->state -= 1;
             ngx_http_tfs_remove_block_cache(t, segment_data);
-            return NGX_OK;
+
+        } else {
+            /* skip GET_BLK_INFO state */
+            t->state += 1;
+            ngx_http_tfs_peer_set_addr(t->pool,
+                          &t->tfs_peer_servers[NGX_HTTP_TFS_DATA_SERVER], addr);
         }
 
-        ngx_http_tfs_peer_set_addr(t->pool,
-                          &t->tfs_peer_servers[NGX_HTTP_TFS_DATA_SERVER], addr);
+       break;
+    case NGX_ERROR:
+        /* block cache should not affect, go for ns */
+        ngx_log_error(NGX_LOG_ERR, t->log, 0,
+                      "lookup block cache failed.");
+        break;
     }
+    rc = NGX_OK;
+
+    ngx_http_tfs_finalize_state(t, rc);
 
     return rc;
 }
@@ -300,9 +321,9 @@ void
 ngx_http_tfs_remove_block_cache(ngx_http_tfs_t *t,
     ngx_http_tfs_segment_data_t *segment_data)
 {
-    ngx_http_tfs_block_cache_key_t    key;
+    ngx_http_tfs_block_cache_key_t  key;
 
-    key.ns_addr = *((int64_t*)(&t->name_server_addr));
+    key.ns_addr = *((int64_t *)(&t->name_server_addr));
     key.block_id = segment_data->segment_info.block_id;
     ngx_http_tfs_block_cache_remove(&t->block_cache_ctx, t->pool, t->log,
                                     &key, segment_data->cache_hit);
@@ -319,16 +340,16 @@ ngx_http_tfs_remove_block_cache(ngx_http_tfs_t *t,
 ngx_int_t
 ngx_http_tfs_batch_lookup_block_cache(ngx_http_tfs_t *t)
 {
-    uint32_t                               i, j, block_count;
-    ngx_int_t                              rc;
-    ngx_array_t                            keys, kvs;
-    ngx_http_tfs_segment_data_t           *segment_data;
-    ngx_http_tfs_block_cache_kv_t         *kv;
-    ngx_http_tfs_block_cache_key_t        *key;
+    uint32_t                         i, j, block_count;
+    ngx_int_t                        rc;
+    ngx_array_t                      keys, kvs;
+    ngx_http_tfs_segment_data_t     *segment_data;
+    ngx_http_tfs_block_cache_kv_t   *kv;
+    ngx_http_tfs_block_cache_key_t  *key;
 
     block_count = t->file.segment_count - t->file.segment_index;
-    if (block_count > NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT) {
-        block_count = NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT;
+    if (block_count > NGX_HTTP_TFS_MAX_BATCH_COUNT) {
+        block_count = NGX_HTTP_TFS_MAX_BATCH_COUNT;
     }
 
     rc = ngx_array_init(&keys, t->pool, block_count,
@@ -374,6 +395,28 @@ ngx_http_tfs_batch_lookup_block_cache(ngx_http_tfs_t *t)
             segment_data[j].block_info_src = NGX_HTTP_TFS_FROM_CACHE;
         }
     }
+
+    switch (rc) {
+    case NGX_DECLINED:
+        /* remote cache handler will deal */
+        if (t->block_cache_ctx.use_cache & NGX_HTTP_TFS_REMOTE_BLOCK_CACHE) {
+            return NGX_DECLINED;
+        }
+        rc = NGX_OK;
+        break;
+    case NGX_OK:
+        /* local cache all hit */
+        t->decline_handler = ngx_http_tfs_batch_process_start;
+        rc = NGX_DECLINED;
+        break;
+    case NGX_ERROR:
+        /* block cache should not affect, go for ns */
+        ngx_log_error(NGX_LOG_ERR, t->log, 0,
+                      "batch lookup block cache failed.");
+        rc = NGX_OK;
+    }
+
+    ngx_http_tfs_finalize_state(t, rc);
 
     return rc;
 }
@@ -502,10 +545,10 @@ ngx_http_tfs_reinit(ngx_http_request_t *r, ngx_http_tfs_t *t)
 static void
 ngx_http_tfs_event_handler(ngx_event_t *ev)
 {
-    ngx_http_tfs_t       *t;
-    ngx_connection_t     *c;
-    ngx_http_request_t   *r;
-    ngx_http_log_ctx_t   *ctx;
+    ngx_http_tfs_t      *t;
+    ngx_connection_t    *c;
+    ngx_http_request_t  *r;
+    ngx_http_log_ctx_t  *ctx;
 
     c = ev->data;
     t = c->data;
@@ -533,9 +576,9 @@ ngx_http_tfs_event_handler(ngx_event_t *ev)
 static void
 ngx_http_tfs_send(ngx_http_request_t *r, ngx_http_tfs_t *t)
 {
-    ngx_int_t                                rc;
-    ngx_connection_t                        *c;
-    ngx_http_tfs_peer_connection_t          *tp;
+    ngx_int_t                       rc;
+    ngx_connection_t               *c;
+    ngx_http_tfs_peer_connection_t *tp;
 
     tp = t->tfs_peer;
     c = tp->peer.connection;
@@ -623,8 +666,8 @@ ngx_http_tfs_dummy_handler(ngx_http_request_t *r, ngx_http_tfs_t *t)
 static ngx_int_t
 ngx_http_tfs_alloc_buf(ngx_http_tfs_t *t)
 {
-    ngx_http_request_t               *r;
-    ngx_http_tfs_peer_connection_t   *tp;
+    ngx_http_request_t             *r;
+    ngx_http_tfs_peer_connection_t *tp;
 
     tp = t->tfs_peer;
     r = t->data;
@@ -663,7 +706,7 @@ ngx_http_tfs_alloc_buf(ngx_http_tfs_t *t)
 static ngx_int_t
 ngx_http_tfs_process_header(ngx_http_tfs_t *t, ngx_int_t n)
 {
-    ngx_int_t        body_size, rc;
+    ngx_int_t  body_size, rc;
 
     if (n < t->header_size) {
         t->header_buffer.last += n;
@@ -677,7 +720,8 @@ ngx_http_tfs_process_header(ngx_http_tfs_t *t, ngx_int_t n)
     body_size = n - t->header_size;
     if (t->input_filter != NULL) {
         rc = t->input_filter(t);
-        if (rc != NGX_OK) { /* error or NGX_DONE */
+        if (rc != NGX_OK) {
+            /* error or NGX_DONE */
             return rc;
         }
     }
@@ -693,9 +737,9 @@ ngx_http_tfs_process_header(ngx_http_tfs_t *t, ngx_int_t n)
 void
 ngx_http_tfs_finalize_state(ngx_http_tfs_t *t, ngx_int_t rc)
 {
-    ngx_http_request_t               *r;
-    ngx_peer_connection_t            *p;
-    ngx_http_tfs_peer_connection_t   *tp;
+    ngx_http_request_t              *r;
+    ngx_peer_connection_t           *p;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     r = t->data;
     tp = t->tfs_peer;
@@ -739,7 +783,7 @@ ngx_http_tfs_finalize_state(ngx_http_tfs_t *t, ngx_int_t rc)
     }
 
     if (rc >= NGX_HTTP_SPECIAL_RESPONSE
-       || rc <= NGX_HTTP_TFS_EXIT_GENERAL_ERROR)
+        || rc <= NGX_HTTP_TFS_EXIT_GENERAL_ERROR)
     {
         t->tfs_status = rc;
         ngx_http_tfs_send_response(r, t);
@@ -759,7 +803,6 @@ ngx_http_tfs_finalize_state(ngx_http_tfs_t *t, ngx_int_t rc)
                 ngx_http_tfs_finalize_request(r, t, NGX_HTTP_NOT_FOUND);
                 return;
             }
-
         }
 
         t->tfs_status = NGX_ERROR;
@@ -790,27 +833,33 @@ ngx_http_tfs_finalize_state(ngx_http_tfs_t *t, ngx_int_t rc)
         return;
     }
 
-    if (p) {
+    if (p && p->free) {
         p->free(p, p->data, 0);
     }
 
     if (rc == NGX_DECLINED) {
+        if (t->decline_handler) {
+            rc = t->decline_handler(t);
+            if (rc == NGX_ERROR) {
+                ngx_http_tfs_finalize_request(r, t, NGX_ERROR);
+            }
+        }
         return;
     }
 
     /* rc == NGX_OK */
     if (ngx_http_tfs_reinit(r, t) != NGX_OK) {
-        ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                      "tfs reinit failed");
+        ngx_log_error(NGX_LOG_ERR, t->log, 0, "tfs reinit failed");
         ngx_http_tfs_finalize_request(r, t, NGX_HTTP_INTERNAL_SERVER_ERROR);
+
         return;
     }
 
     t->tfs_peer = ngx_http_tfs_select_peer(t);
     if (t->tfs_peer == NULL) {
-        ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                      "tfs select peer failed");
+        ngx_log_error(NGX_LOG_ERR, t->log, 0, "tfs select peer failed");
         ngx_http_tfs_finalize_request(r, t, NGX_HTTP_INTERNAL_SERVER_ERROR);
+
         return;
     }
 
@@ -829,10 +878,10 @@ ngx_http_tfs_finalize_state(ngx_http_tfs_t *t, ngx_int_t rc)
 static void
 ngx_http_tfs_process_upstream_request(ngx_http_request_t *r, ngx_http_tfs_t *t)
 {
-    ngx_int_t                         n, rc;
-    ngx_chain_t                      *chain;
-    ngx_connection_t                 *c;
-    ngx_http_tfs_peer_connection_t   *tp;
+    ngx_int_t                        n, rc;
+    ngx_chain_t                     *chain;
+    ngx_connection_t                *c;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     tp = t->tfs_peer;
     c = tp->peer.connection;
@@ -899,9 +948,9 @@ ngx_http_tfs_process_upstream_request(ngx_http_request_t *r, ngx_http_tfs_t *t)
         }
 
         if (n == NGX_ERROR || n == 0) {
-            ngx_log_error(NGX_LOG_ERR, c->log, 0,
-                          "recv chain error");
+            ngx_log_error(NGX_LOG_ERR, c->log, 0, "recv chain error");
             ngx_http_tfs_finalize_request(r, t, NGX_HTTP_INTERNAL_SERVER_ERROR);
+
             return;
         }
 
@@ -943,10 +992,10 @@ ngx_http_tfs_process_upstream_request(ngx_http_request_t *r, ngx_http_tfs_t *t)
 static void
 ngx_http_tfs_send_response(ngx_http_request_t *r, ngx_http_tfs_t *t)
 {
-    int                           tcp_nodelay;
-    ngx_int_t                     rc;
-    ngx_connection_t             *c;
-    ngx_http_core_loc_conf_t     *clcf;
+    int                        tcp_nodelay;
+    ngx_int_t                  rc;
+    ngx_connection_t          *c;
+    ngx_http_core_loc_conf_t  *clcf;
 
     /* sub process */
     if (t->parent) {
@@ -978,12 +1027,10 @@ ngx_http_tfs_send_response(ngx_http_request_t *r, ngx_http_tfs_t *t)
         }
     }
 
-    if (!t->header_sent) {
+    if (!r->header_sent) {
         ngx_http_tfs_set_header_line(t);
 
         rc = ngx_http_send_header(r);
-
-        t->header_sent = 1;
 
         if (rc == NGX_ERROR || rc > NGX_OK || r->post_action) {
             ngx_http_tfs_finalize_state(t, rc);
@@ -1047,9 +1094,11 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
     case NGX_HTTP_TFS_EXIT_GENERAL_ERROR:
         r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
         goto error_header;
+
     case NGX_HTTP_SPECIAL_RESPONSE ... NGX_HTTP_INTERNAL_SERVER_ERROR:
         r->headers_out.status = t->tfs_status;
         goto error_header;
+
     case NGX_HTTP_TFS_EXIT_INVALID_FILE_NAME:
     case NGX_HTTP_TFS_EXIT_READ_OFFSET_ERROR:
     case NGX_HTTP_TFS_EXIT_DISK_OPER_INCOMPLETE:
@@ -1057,11 +1106,13 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
     case NGX_HTTP_TFS_EXIT_PHYSIC_BLOCK_OFFSET_ERROR:
         r->headers_out.status = NGX_HTTP_BAD_REQUEST;
         goto error_header;
+
     case NGX_HTTP_TFS_EXIT_OVER_MAX_SUB_DIRS_COUNT:
     case NGX_HTTP_TFS_EXIT_OVER_MAX_SUB_DIRS_DEEP:
     case NGX_HTTP_TFS_EXIT_OVER_MAX_SUB_FILES_COUNT:
         r->headers_out.status = NGX_HTTP_FORBIDDEN;
         goto error_header;
+
     case NGX_HTTP_TFS_EIXT_SERVER_OBJECT_NOT_FOUND:
     case NGX_HTTP_TFS_EXIT_BLOCK_NOT_FOUND:
     case NGX_HTTP_TFS_EXIT_META_NOT_FOUND_ERROR:
@@ -1069,6 +1120,7 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
     case NGX_HTTP_TFS_EXIT_FILE_STATUS_ERROR:
         r->headers_out.status = NGX_HTTP_NOT_FOUND;
         goto error_header;
+
     case NGX_HTTP_TFS_EXIT_WRITE_EXIST_POS_ERROR:
     case NGX_HTTP_TFS_EXIT_VERSION_CONFLICT_ERROR:
         /* TODO: maybe should handle this using retry */
@@ -1081,11 +1133,13 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
         ngx_http_tfs_clear_content_len();
         r->headers_out.status = NGX_HTTP_OK;
         break;
+
     case NGX_HTTP_TFS_ACTION_GET_APPID:
         r->headers_out.content_type_len = sizeof("application/json") - 1;
         ngx_str_set(&r->headers_out.content_type, "application/json");
         r->headers_out.status = NGX_HTTP_OK;
         break;
+
     case NGX_HTTP_TFS_ACTION_CREATE_DIR:
     case NGX_HTTP_TFS_ACTION_CREATE_FILE:
         switch (t->state) {
@@ -1094,21 +1148,26 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
             r->headers_out.status = NGX_HTTP_CREATED;
             break;
             /* errno */
+
         default:
             switch (t->tfs_status) {
             case NGX_HTTP_TFS_EXIT_TARGET_EXIST_ERROR:
                 r->headers_out.status = NGX_HTTP_CONFLICT;
                 break;
+
             case NGX_HTTP_TFS_EXIT_PARENT_EXIST_ERROR:
                 r->headers_out.status = NGX_HTTP_NOT_FOUND;
                 break;
+
             default:
                 r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
                 break;
             }
+
             goto error_header;
         }
         break;
+
     case NGX_HTTP_TFS_ACTION_WRITE_FILE:
         switch (t->state) {
         case NGX_HTTP_TFS_STATE_WRITE_DONE:
@@ -1128,15 +1187,19 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
             case NGX_HTTP_TFS_EXIT_NOT_CREATE_ERROR:
                 r->headers_out.status = NGX_HTTP_NOT_FOUND;
                 break;
+
             case NGX_HTTP_TFS_EXIT_WRITE_EXIST_POS_ERROR:
                 r->headers_out.status = NGX_HTTP_BAD_REQUEST;
                 break;
+
             default:
                 r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
                 break;
             }
+
             goto error_header;
         }
+
         break;
 
     case NGX_HTTP_TFS_ACTION_STAT_FILE:
@@ -1146,6 +1209,7 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
             ngx_str_set(&r->headers_out.content_type, "application/json");
             r->headers_out.status = NGX_HTTP_OK;
             break;
+
             /* errno */
         default:
             switch (t->tfs_status) {
@@ -1153,9 +1217,11 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
                 r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
                 break;
             }
+
             goto error_header;
         }
         break;
+
     case NGX_HTTP_TFS_ACTION_REMOVE_FILE:
         switch (t->state) {
         case NGX_HTTP_TFS_STATE_REMOVE_DONE:
@@ -1173,9 +1239,11 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
                 r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
                 break;
             }
+
             goto error_header;
         }
         break;
+
     case NGX_HTTP_TFS_ACTION_READ_FILE:
         switch (t->state) {
             /* maybe process buf overflow */
@@ -1186,8 +1254,14 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
                 ngx_str_set(&r->headers_out.content_type, "application/json");
             }
 
+            /* set last-modified if have */
+            if (t->file_info.modify_time > 0) {
+                r->headers_out.last_modified_time = t->file_info.modify_time;
+            }
+
             r->headers_out.status = NGX_HTTP_OK;
             break;
+
         default:
             switch (t->tfs_status) {
             case NGX_HTTP_TFS_EXIT_TARGET_EXIST_ERROR:
@@ -1198,15 +1272,18 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
                 r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
                 break;
             }
+
             goto error_header;
         }
         break;
+
     case NGX_HTTP_TFS_ACTION_REMOVE_DIR:
         switch (t->state) {
         case NGX_HTTP_TFS_STATE_ACTION_DONE:
             ngx_http_tfs_clear_content_len();
             r->headers_out.status = NGX_HTTP_OK;
             break;
+
         default:
             switch (t->tfs_status) {
             case NGX_HTTP_TFS_EXIT_TARGET_EXIST_ERROR:
@@ -1220,9 +1297,11 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
                 r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
                 break;
             }
+
             goto error_header;
         }
         break;
+
     case NGX_HTTP_TFS_ACTION_LS_DIR:
     case NGX_HTTP_TFS_ACTION_LS_FILE:
         switch (t->state) {
@@ -1285,8 +1364,7 @@ ngx_http_tfs_set_header_line(ngx_http_tfs_t *t)
 error_header:
     ngx_http_tfs_clear_content_len();
 
-    ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                  "%V failed, err(%d)",
+    ngx_log_error(NGX_LOG_ERR, t->log, 0, "%V failed, err(%d)",
                   &ctx->action.msg, t->tfs_status);
 }
 
@@ -1294,16 +1372,16 @@ error_header:
 static void
 ngx_http_tfs_process_non_buffered_downstream(ngx_http_request_t *r)
 {
-    ngx_event_t          *wev;
-    ngx_http_tfs_t       *t;
-    ngx_connection_t     *c;
+    ngx_event_t       *wev;
+    ngx_http_tfs_t    *t;
+    ngx_connection_t  *c;
 
     c = r->connection;
     wev = c->write;
     t = ngx_http_get_module_ctx(r, ngx_http_tfs_module);
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
-                   "http tfs upstream process  downstream");
+                   "http tfs upstream process downstream");
 
     c->log->action = "sending to client";
 
@@ -1311,7 +1389,7 @@ ngx_http_tfs_process_non_buffered_downstream(ngx_http_request_t *r)
         c->timedout = 1;
         ngx_connection_error(c, NGX_ETIMEDOUT, "client timed out");
         ngx_http_tfs_finalize_request(t->data, t,
-                                      NGX_HTTP_INTERNAL_SERVER_ERROR);
+                                      NGX_HTTP_REQUEST_TIME_OUT);
         return;
     }
 
@@ -1323,13 +1401,13 @@ static void
 ngx_http_tfs_process_non_buffered_request(ngx_http_tfs_t *t,
     ngx_uint_t do_write)
 {
-    size_t                           size;
-    ssize_t                          n;
-    ngx_int_t                        rc, finalize_state;
-    ngx_buf_t                       *b;
-    ngx_connection_t                *downstream, *upstream;
-    ngx_http_request_t              *r;
-    ngx_http_core_loc_conf_t        *clcf;
+    size_t                     size;
+    ssize_t                    n;
+    ngx_int_t                  rc, finalize_state;
+    ngx_buf_t                 *b;
+    ngx_connection_t          *downstream, *upstream;
+    ngx_http_request_t        *r;
+    ngx_http_core_loc_conf_t  *clcf;
 
     r = t->data;
     finalize_state = 0;
@@ -1377,6 +1455,7 @@ ngx_http_tfs_process_non_buffered_request(ngx_http_tfs_t *t,
                     if (t->r_ctx.action.code == NGX_HTTP_TFS_ACTION_READ_FILE
                         && t->state == NGX_HTTP_TFS_STATE_READ_DONE)
                     {
+                        ngx_http_tfs_clear_buf(b);
                         ngx_http_tfs_finalize_request(r, t, NGX_DONE);
                         return;
                     }
@@ -1396,7 +1475,7 @@ ngx_http_tfs_process_non_buffered_request(ngx_http_tfs_t *t,
                 {
                     /* need log size */
                     ngx_log_error(NGX_LOG_INFO, t->log, 0,
-                                  "%V , output %uL byte",
+                                  "%V, output %uL byte",
                                   &t->r_ctx.action.msg, t->output_size);
                     ngx_http_tfs_finalize_request(r, t, 0);
                     return;
@@ -1472,10 +1551,11 @@ ngx_http_tfs_process_non_buffered_request(ngx_http_tfs_t *t,
     }
 }
 
+
 static void
 ngx_http_tfs_process_buf_overflow(ngx_http_request_t *r, ngx_http_tfs_t *t)
 {
-    ngx_int_t                rc;
+    ngx_int_t  rc;
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                   "tfs process buf overflow, %V", t->tfs_peer->peer.name);
@@ -1491,6 +1571,7 @@ ngx_http_tfs_process_buf_overflow(ngx_http_request_t *r, ngx_http_tfs_t *t)
                               "process request body failed");
                 ngx_http_tfs_finalize_request(t->data, t,
                                               NGX_HTTP_INTERNAL_SERVER_ERROR);
+
             } else {
                 ngx_http_tfs_finalize_state(t, rc);
             }
@@ -1525,9 +1606,9 @@ void
 ngx_http_tfs_finalize_request(ngx_http_request_t *r, ngx_http_tfs_t *t,
     ngx_int_t rc)
 {
-    ngx_uint_t                     i;
-    ngx_http_tfs_t                *next_st;
-    ngx_peer_connection_t         *p;
+    ngx_uint_t              i;
+    ngx_http_tfs_t         *next_st;
+    ngx_peer_connection_t  *p;
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "finalize http tfs request: %i", rc);
@@ -1566,6 +1647,8 @@ ngx_http_tfs_finalize_request(ngx_http_request_t *r, ngx_http_tfs_t *t,
         next_st = t->next;
         ngx_http_tfs_free_st(t);
 
+        r->write_event_handler = ngx_http_request_empty_handler;
+
         if (rc == NGX_DONE) {
             t->parent->sp_succ_count++;
             t->parent->stat_info.size += t->stat_info.size;
@@ -1576,6 +1659,9 @@ ngx_http_tfs_finalize_request(ngx_http_request_t *r, ngx_http_tfs_t *t,
 
         } else {
             t->parent->sp_fail_count++;
+            if (rc == NGX_HTTP_REQUEST_TIME_OUT) {
+                t->parent->request_timeout = NGX_HTTP_TFS_YES;
+            }
         }
         t->parent->sp_done_count++;
         t->parent->sp_curr++;
@@ -1587,7 +1673,7 @@ ngx_http_tfs_finalize_request(ngx_http_request_t *r, ngx_http_tfs_t *t,
             if (t->r_ctx.action.code == NGX_HTTP_TFS_ACTION_READ_FILE) {
                 /* wake up next sub process */
                 ngx_log_debug1(NGX_LOG_DEBUG_HTTP, t->log, 0,
-                               "segment [%uD] output complete, call next...",
+                               "segment[%uD] output complete, call next...",
                                t->sp_curr);
                 if (next_st) {
                     next_st->sp_callback(next_st);
@@ -1620,8 +1706,8 @@ ngx_http_tfs_finalize_request(ngx_http_request_t *r, ngx_http_tfs_t *t,
 static void
 ngx_http_tfs_read_handler(ngx_http_request_t *r, ngx_http_tfs_t *t)
 {
-    ngx_connection_t                 *c;
-    ngx_http_tfs_peer_connection_t   *tp;
+    ngx_connection_t               *c;
+    ngx_http_tfs_peer_connection_t *tp;
 
     tp = t->tfs_peer;
     c = tp->peer.connection;
@@ -1646,8 +1732,8 @@ ngx_http_tfs_read_handler(ngx_http_request_t *r, ngx_http_tfs_t *t)
 static void
 ngx_http_tfs_send_handler(ngx_http_request_t *r, ngx_http_tfs_t *t)
 {
-    ngx_connection_t                 *c;
-    ngx_http_tfs_peer_connection_t   *tp;
+    ngx_connection_t                *c;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     tp = t->tfs_peer;
     c = tp->peer.connection;
@@ -1672,17 +1758,18 @@ static void
 ngx_http_tfs_handle_connection_failure(ngx_http_tfs_t *t,
     ngx_http_tfs_peer_connection_t *tp)
 {
-    ngx_connection_t                 *c;
-    ngx_peer_connection_t            *p;
+    ngx_connection_t            *c;
+    ngx_peer_connection_t       *p;
 #if (NGX_DEBUG)
-    ngx_http_connection_pool_t       *pool;
+    ngx_http_connection_pool_t  *pool;
 #endif
 
     p = &tp->peer;
     c = p->connection;
 #if (NGX_DEBUG)
     /* failure connection can not be freed,
-     so make sure get&free op pairs are right */
+     * so make sure get&free op pairs are right
+     */
     pool = p->data;
     pool->count++;
 #endif
@@ -1724,7 +1811,7 @@ ngx_http_tfs_handle_connection_failure(ngx_http_tfs_t *t,
 ngx_int_t
 ngx_http_tfs_set_output_appid(ngx_http_tfs_t *t, uint64_t app_id)
 {
-    ngx_chain_t                 *cl, **ll;
+    ngx_chain_t  *cl, **ll;
 
     t->json_output = ngx_http_tfs_json_init(t->log, t->pool);
     if (t->json_output == NULL) {
@@ -1757,10 +1844,12 @@ ngx_http_tfs_set_custom_initial_parameters(ngx_http_tfs_t *t)
     case NGX_HTTP_TFS_ACTION_CREATE_FILE:
         t->last_file_path = t->r_ctx.file_path_s;
         break;
+
     case NGX_HTTP_TFS_ACTION_MOVE_DIR:
     case NGX_HTTP_TFS_ACTION_MOVE_FILE:
         t->last_file_path = t->r_ctx.file_path_d;
         break;
+
     case NGX_HTTP_TFS_ACTION_LS_DIR:
     case NGX_HTTP_TFS_ACTION_LS_FILE:
         /* set initial ls parameter */
@@ -1768,6 +1857,7 @@ ngx_http_tfs_set_custom_initial_parameters(ngx_http_tfs_t *t)
         t->last_file_pid = -1;
         t->last_file_type = t->r_ctx.file_type;
         break;
+
     case NGX_HTTP_TFS_ACTION_READ_FILE:
     case NGX_HTTP_TFS_ACTION_REMOVE_FILE:
         t->file.file_offset = t->r_ctx.offset;
@@ -1780,11 +1870,11 @@ ngx_http_tfs_set_custom_initial_parameters(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_misc_ctx_init(ngx_http_tfs_t *t, ngx_http_tfs_rcs_info_t *rc_info)
 {
-    ngx_int_t                                rc;
-    ngx_http_request_t                      *r;
-    ngx_http_tfs_inet_t                     *addr;
-    ngx_http_tfs_logical_cluster_t          *logical_cluster;
-    ngx_http_tfs_physical_cluster_t         *physical_cluster;
+    ngx_int_t                         rc;
+    ngx_http_request_t               *r;
+    ngx_http_tfs_inet_t              *addr;
+    ngx_http_tfs_logical_cluster_t   *logical_cluster;
+    ngx_http_tfs_physical_cluster_t  *physical_cluster;
 
     /* raw tfs */
     if (t->r_ctx.version == 1) {
@@ -1792,17 +1882,21 @@ ngx_http_tfs_misc_ctx_init(ngx_http_tfs_t *t, ngx_http_tfs_rcs_info_t *rc_info)
         case NGX_HTTP_TFS_ACTION_STAT_FILE:
             t->state = NGX_HTTP_TFS_STATE_STAT_GET_BLK_INFO;
             break;
+
         case NGX_HTTP_TFS_ACTION_READ_FILE:
             t->state = NGX_HTTP_TFS_STATE_READ_GET_BLK_INFO;
             break;
+
         case NGX_HTTP_TFS_ACTION_WRITE_FILE:
             t->state = NGX_HTTP_TFS_STATE_WRITE_CLUSTER_ID_NS;
             break;
+
         case NGX_HTTP_TFS_ACTION_REMOVE_FILE:
             t->state = NGX_HTTP_TFS_STATE_REMOVE_GET_BLK_INFO;
             if (!t->is_large_file && rc_info->need_duplicate) {
                 /* undelete, conceal and reveal
-                 * do not go through de-duplicating */
+                 * do not go through de-duplicating
+                 */
                 if (t->r_ctx.unlink_type == NGX_HTTP_TFS_UNLINK_DELETE) {
                     t->is_stat_dup_file = NGX_HTTP_TFS_YES;
                     t->r_ctx.read_stat_type = NGX_HTTP_TFS_READ_STAT_FORCE;
@@ -1864,7 +1958,8 @@ ngx_http_tfs_misc_ctx_init(ngx_http_tfs_t *t, ngx_http_tfs_rcs_info_t *rc_info)
 
             } else {
                 /* set oper size && offset,
-                 large file must read the whole meta segment */
+                 * large file must read the whole meta segment
+                 */
                 if (t->is_large_file) {
                     t->is_process_meta_seg = NGX_HTTP_TFS_YES;
                     t->file.file_offset = 0;
@@ -1901,6 +1996,9 @@ ngx_http_tfs_misc_ctx_init(ngx_http_tfs_t *t, ngx_http_tfs_rcs_info_t *rc_info)
             /* update root server & meta table */
             t->loc_conf->meta_root_server = rc_info->meta_root_server;
             t->loc_conf->meta_server_table.version = 0;
+            ngx_http_tfs_peer_set_addr(t->pool,
+                             &t->tfs_peer_servers[NGX_HTTP_TFS_ROOT_SERVER],
+                             (ngx_http_tfs_inet_t *)&rc_info->meta_root_server);
         }
 
         /* next => root server */
@@ -1917,17 +2015,13 @@ ngx_http_tfs_misc_ctx_init(ngx_http_tfs_t *t, ngx_http_tfs_rcs_info_t *rc_info)
 
             ngx_http_tfs_peer_set_addr(t->pool,
                           &t->tfs_peer_servers[NGX_HTTP_TFS_META_SERVER], addr);
-
-        } else {
-            ngx_http_tfs_peer_set_addr(t->pool,
-                             &t->tfs_peer_servers[NGX_HTTP_TFS_ROOT_SERVER],
-                             (ngx_http_tfs_inet_t *)&rc_info->meta_root_server);
         }
     }
 
-    /* prepare:
-       read: remote block cache instance
-       write(large file and custom file): each segment's data */
+    /* prepare:read:
+     * remote block cache instance write(large file and custom file):
+     * each segment's data
+     */
     switch (t->r_ctx.action.code) {
     case NGX_HTTP_TFS_ACTION_REMOVE_FILE:
         t->group_seq = -1;
@@ -1959,22 +2053,11 @@ ngx_http_tfs_misc_ctx_init(ngx_http_tfs_t *t, ngx_http_tfs_rcs_info_t *rc_info)
 
         /* lookup block cache */
         if (t->r_ctx.version == 1) {
-            rc = ngx_http_tfs_lookup_block_cache(t,
-                                  &t->file.segment_data[t->file.segment_index]);
-            if (rc == NGX_ERROR) {
-                ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                              "lookup block cache failed");
-                return NGX_OK;
-            }
-
-            if (rc == NGX_DECLINED
-                && (t->block_cache_ctx.use_cache
-                    & NGX_HTTP_TFS_REMOTE_BLOCK_CACHE))
-            {
-                return NGX_DECLINED;
-            }
+            t->decline_handler = ngx_http_tfs_lookup_block_cache;
+            return NGX_DECLINED;
         }
         break;
+
     case NGX_HTTP_TFS_ACTION_WRITE_FILE:
         if (t->is_large_file || t->r_ctx.version == 2) {
             rc = ngx_http_tfs_get_segment_for_write(t);
@@ -2008,20 +2091,77 @@ ngx_http_tfs_misc_ctx_init(ngx_http_tfs_t *t, ngx_http_tfs_rcs_info_t *rc_info)
             return NGX_OK;
         }
 
-        r = t->data;
-        rc = ngx_http_tfs_get_duplicate_info(&t->dedup_ctx, t->pool,
-                                             t->log, r->request_body->bufs);
-        if (rc == NGX_ERROR) {
-            /* no dedup */
-            return NGX_OK;
-        }
-
         t->use_dedup = NGX_HTTP_TFS_YES;
         /* dedup do not allow retry other ns */
         t->retry_curr_ns = NGX_HTTP_TFS_YES;
 
-        /* NGX_DECLINED */
-        return rc;
+        r = t->data;
+        t->dedup_ctx.file_data = r->request_body->bufs;
+        t->decline_handler = ngx_http_tfs_get_duplicate_info;
+
+        return NGX_DECLINED;
+    }
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
+ngx_http_tfs_get_duplicate_info(ngx_http_tfs_t *t)
+{
+    ngx_int_t  rc;
+
+    rc = ngx_http_tfs_dedup_get(&t->dedup_ctx, t->pool, t->log);
+    if (rc == NGX_ERROR) {
+        if (t->r_ctx.action.code == NGX_HTTP_TFS_ACTION_REMOVE_FILE
+            && t->state == NGX_HTTP_TFS_STATE_REMOVE_READ_META_SEGMENT)
+        {
+            /* get dup info from tair failed, do not unlink file */
+            t->state = NGX_HTTP_TFS_STATE_REMOVE_DONE;
+            rc = NGX_DONE;
+
+        } else {
+            /* no dedup */
+            rc = NGX_OK;
+        }
+
+        ngx_http_tfs_finalize_state(t, rc);
+    }
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
+ngx_http_tfs_set_duplicate_info(ngx_http_tfs_t *t)
+{
+    ngx_int_t  rc;
+
+    rc = ngx_http_tfs_dedup_set(&t->dedup_ctx, t->pool,
+                                t->log);
+    /* save tair failed */
+    if (rc == NGX_ERROR) {
+        if (t->r_ctx.action.code == NGX_HTTP_TFS_ACTION_WRITE_FILE) {
+            switch (t->state) {
+            case NGX_HTTP_TFS_STATE_WRITE_STAT_DUP_FILE:
+                /* stat success and file status normal */
+                /* need save new tfs file, no more dedup */
+                t->state = NGX_HTTP_TFS_STATE_WRITE_CLUSTER_ID_NS;
+                t->is_stat_dup_file = NGX_HTTP_TFS_NO;
+                t->use_dedup = NGX_HTTP_TFS_NO;
+                /* need reset output buf */
+                t->out_bufs = NULL;
+                /* need reset block id and file id */
+                t->file.segment_data[0].segment_info.block_id = 0;
+                t->file.segment_data[0].segment_info.file_id = 0;
+                rc = NGX_OK;
+                break;
+            case NGX_HTTP_TFS_STATE_WRITE_DONE:
+                rc = NGX_DONE;
+            }
+        }
+
+        ngx_http_tfs_finalize_state(t, rc);
     }
 
     return NGX_OK;
@@ -2031,16 +2171,16 @@ ngx_http_tfs_misc_ctx_init(ngx_http_tfs_t *t, ngx_http_tfs_rcs_info_t *rc_info)
 ngx_int_t
 ngx_http_tfs_batch_process_start(ngx_http_tfs_t *t)
 {
-    uint32_t                               block_count, i;
-    ngx_http_tfs_t                        *st, **tt;
-    ngx_http_tfs_inet_t                   *addr;
-    ngx_http_tfs_segment_data_t           *segment_data;
-    ngx_http_tfs_peer_connection_t        *data_server;
+    uint32_t                         block_count, i;
+    ngx_http_tfs_t                  *st, **tt;
+    ngx_http_tfs_inet_t             *addr;
+    ngx_http_tfs_segment_data_t     *segment_data;
+    ngx_http_tfs_peer_connection_t  *data_server;
 
     segment_data = &t->file.segment_data[t->file.segment_index];
     block_count = t->file.segment_count - t->file.segment_index;
-    if (block_count > NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT) {
-        block_count = NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT;
+    if (block_count > NGX_HTTP_TFS_MAX_BATCH_COUNT) {
+        block_count = NGX_HTTP_TFS_MAX_BATCH_COUNT;
     }
 
     t->sp_count = 0;
@@ -2051,11 +2191,10 @@ ngx_http_tfs_batch_process_start(ngx_http_tfs_t *t)
     t->sp_callback = ngx_http_tfs_batch_process_end;
     tt = &t->next;
 
+    /* create sub process */
     for (i = 0; i < block_count; i++) {
         st = ngx_http_tfs_alloc_st(t);
         if (st == NULL) {
-            ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                          "alloc st[%uD] failed.", i);
             return NGX_ERROR;
         }
 
@@ -2072,7 +2211,7 @@ ngx_http_tfs_batch_process_start(ngx_http_tfs_t *t)
         st->file.segment_index = 0;
         st->file.segment_data = &segment_data[i];
         st->sp_curr = t->file.segment_index + i;
-        st->sp_ready = 0;
+        st->sp_ready = NGX_HTTP_TFS_NO;
 
         if (t->r_ctx.action.code == NGX_HTTP_TFS_ACTION_WRITE_FILE) {
             st->file.left_length = st->file.segment_data->segment_info.size;
@@ -2107,8 +2246,6 @@ ngx_http_tfs_batch_process_start(ngx_http_tfs_t *t)
         /* select data server */
         addr = ngx_http_tfs_select_data_server(st, st->file.segment_data);
         if (addr == NULL) {
-            ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                          "st[%uD] select data server failed.", i);
             return NGX_ERROR;
         }
 
@@ -2121,15 +2258,11 @@ ngx_http_tfs_batch_process_start(ngx_http_tfs_t *t)
                        data_server->peer_addr_text);
 
         if (ngx_http_tfs_reinit(t->data, st) != NGX_OK) {
-            ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                          "st[%uD] reinit failed.", i);
             return NGX_ERROR;
         }
 
         st->tfs_peer = ngx_http_tfs_select_peer(st);
         if (st->tfs_peer == NULL) {
-            ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                          "st[%uD] select peer failed.", i);
             return NGX_ERROR;
         }
 
@@ -2139,8 +2272,6 @@ ngx_http_tfs_batch_process_start(ngx_http_tfs_t *t)
         *tt = st;
         tt = &st->next;
 
-        ngx_http_tfs_connect(st);
-
         t->sp_count++;
 
         if (t->file.left_length == 0) {
@@ -2149,6 +2280,13 @@ ngx_http_tfs_batch_process_start(ngx_http_tfs_t *t)
     }
     *tt = NULL;
 
+    /* start sub process */
+    for (st = t->next; st; st = t->next) {
+        /* st->next may be modified after recycled to free_st */
+        t->next = st->next;
+        ngx_http_tfs_connect(st);
+    }
+
     return NGX_OK;
 }
 
@@ -2156,9 +2294,9 @@ ngx_http_tfs_batch_process_start(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_batch_process_end(ngx_http_tfs_t *t)
 {
-    ngx_int_t                        rc = NGX_ERROR;
-    ngx_buf_t                       *body_buffer;
-    ngx_http_request_t              *r;
+    ngx_int_t            rc = NGX_ERROR;
+    ngx_buf_t           *body_buffer;
+    ngx_http_request_t  *r;
 
     /* error in sub process */
     if (t->sp_fail_count > 0) {
@@ -2166,11 +2304,20 @@ ngx_http_tfs_batch_process_end(ngx_http_tfs_t *t)
                       "sub process error, rest segment count: %D ",
                       t->file.segment_count - t->file.segment_index);
 
-        ngx_http_tfs_finalize_state(t, NGX_ERROR);
+        if (t->request_timeout) {
+            ngx_http_tfs_finalize_request(t->data, t, NGX_HTTP_REQUEST_TIME_OUT);
+
+        } else {
+            ngx_http_tfs_finalize_state(t, NGX_ERROR);
+        }
         return NGX_ERROR;
     }
 
     t->file.segment_index += t->sp_count;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, t->log, 0,
+                   "batch process segment count: %uD, rest segment count: %D ",
+                   t->sp_count, t->file.segment_count - t->file.segment_index);
 
     if (t->r_ctx.action.code == NGX_HTTP_TFS_ACTION_WRITE_FILE) {
         /* large_file data segment && custom file */
@@ -2198,6 +2345,7 @@ ngx_http_tfs_batch_process_end(ngx_http_tfs_t *t)
         } else if (t->r_ctx.version == 2) {
             t->state = NGX_HTTP_TFS_STATE_WRITE_WRITE_MS;
         }
+
         rc = NGX_OK;
 
     } else if (t->r_ctx.action.code == NGX_HTTP_TFS_ACTION_READ_FILE) {
@@ -2209,60 +2357,32 @@ ngx_http_tfs_batch_process_end(ngx_http_tfs_t *t)
             /* batch lookup block cache */
             t->block_cache_ctx.curr_lookup_cache =
                                                NGX_HTTP_TFS_LOCAL_BLOCK_CACHE;
-            rc = ngx_http_tfs_batch_lookup_block_cache(t);
-            if (rc == NGX_OK) {
-                /* local cache all hit */
-                rc = ngx_http_tfs_batch_process_start(t);
-                if (rc == NGX_ERROR) {
-                    return NGX_ERROR;
-                }
-                rc = NGX_DECLINED;
+            return ngx_http_tfs_batch_lookup_block_cache(t);
+        }
 
-            } else if (rc == NGX_DECLINED) {
-                /* local cache has miss, go for ns */
-                if (!(t->block_cache_ctx.use_cache
-                      & NGX_HTTP_TFS_REMOTE_BLOCK_CACHE))
-                {
-                    rc = NGX_OK;
-                }
+        /* read over, restore request's ctx */
+        r = t->data;
+        ngx_http_set_ctx(r, t, ngx_http_tfs_module);
+        rc = NGX_DONE;
 
-            } else if (rc == NGX_ERROR) {
-                /* block cache should not affect, go for ns */
-                ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                              "batch lookup block cache failed.");
+        if (t->is_large_file) {
+            t->state = NGX_HTTP_TFS_STATE_READ_DONE;
+            t->file_name = t->r_ctx.file_path_s;
+        }
+
+        if (t->r_ctx.version == 2) {
+            if (t->file.still_have) {
+                t->state = NGX_HTTP_TFS_STATE_READ_GET_FRAG_INFO;
+                body_buffer =
+                 &t->tfs_peer_servers[NGX_HTTP_TFS_META_SERVER].body_buffer;
+                ngx_http_tfs_clear_buf(body_buffer);
                 rc = NGX_OK;
-            }
 
-        /* read over */
-        } else {
-            /* restore request's ctx */
-            r = t->data;
-            ngx_http_set_ctx(r, t, ngx_http_tfs_module);
-            rc = NGX_DONE;
-
-            if (t->is_large_file) {
+            } else {
                 t->state = NGX_HTTP_TFS_STATE_READ_DONE;
-                t->file_name = t->r_ctx.file_path_s;
-            }
-
-            if (t->r_ctx.version == 2) {
-                if (t->file.still_have) {
-                    t->state = NGX_HTTP_TFS_STATE_READ_GET_FRAG_INFO;
-                    body_buffer =
-                     &t->tfs_peer_servers[NGX_HTTP_TFS_META_SERVER].body_buffer;
-                    ngx_http_tfs_clear_buf(body_buffer);
-                    rc = NGX_OK;
-
-                } else {
-                    t->state = NGX_HTTP_TFS_STATE_READ_DONE;
-                }
             }
         }
     }
-
-    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, t->log, 0,
-                   "batch process segment count: %uD, rest segment count: %D ",
-                   t->sp_count, t->file.segment_count - t->file.segment_index);
 
     ngx_http_tfs_finalize_state(t, rc);
 
@@ -2274,10 +2394,19 @@ ngx_int_t
 ngx_http_tfs_batch_process_next(ngx_http_tfs_t *t)
 {
     if (t->sp_ready) {
+        if (t->parent->sp_fail_count > 0) {
+            ngx_log_error(NGX_LOG_ERR, t->log, 0,
+                          "other sub process failed, will fail myself");
+
+            ngx_http_tfs_finalize_request(t->data, t, NGX_ERROR);
+            return NGX_OK;;
+        }
+
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, t->log, 0,
-                       "segment [%uD] wake up, will output...",
+                       "segment[%uD] wake up, will output...",
                        t->sp_curr);
         ngx_http_tfs_send_response(t->data, t);
     }
+
     return NGX_OK;
 }

--- a/src/ngx_http_tfs.h
+++ b/src/ngx_http_tfs.h
@@ -24,12 +24,13 @@
 #include <ngx_http_tfs_timers.h>
 
 
-typedef ngx_table_elt_t *(*ngx_http_tfs_create_header_pt)(ngx_http_request_t *r);
+typedef ngx_table_elt_t *(*ngx_http_tfs_create_header_pt)
+    (ngx_http_request_t *r);
 
 
 typedef struct {
-    ngx_str_t            state_msg;
-    ngx_int_t            state;
+    ngx_str_t                      state_msg;
+    ngx_int_t                      state;
 } ngx_http_tfs_state_t;
 
 
@@ -49,124 +50,126 @@ typedef enum {
 
 
 typedef struct {
-    uint32_t                               block_id;
-    uint64_t                               file_id;
-    int64_t                                offset;  /* offset in the file */
-    uint32_t                               size;
-    uint32_t                               crc;
+    uint32_t                       block_id;
+    uint64_t                       file_id;
+    int64_t                        offset;  /* offset in the file */
+    uint32_t                       size;
+    uint32_t                       crc;
 } NGX_PACKED ngx_http_tfs_segment_info_t;
 
 
 typedef struct {
-    u_char    file_name[NGX_HTTP_TFS_FILE_NAME_LEN];
-    int64_t   offset;
-    uint32_t  size;
-    uint32_t  crc;
+    u_char                         file_name[NGX_HTTP_TFS_FILE_NAME_LEN];
+    int64_t                        offset;
+    uint32_t                       size;
+    uint32_t                       crc;
 } NGX_PACKED ngx_http_tfs_tmp_segment_info_t;
 
 
 struct ngx_http_tfs_segment_data_s {
-    uint8_t                                cache_hit;
-    ngx_http_tfs_block_info_src_e          block_info_src;
-    ngx_http_tfs_segment_info_t            segment_info;
+    uint8_t                        cache_hit;
+    ngx_http_tfs_block_info_src_e  block_info_src;
+    ngx_http_tfs_segment_info_t    segment_info;
     /* read/write offset inside this segment */
-    uint32_t                               oper_offset;
+    uint32_t                       oper_offset;
     /* read/write size inside this segment */
-    uint32_t                               oper_size;
+    uint32_t                       oper_size;
+    /* current writing data's crc */
+    uint32_t                       curr_crc;
     union {
-        uint64_t                           write_file_number;
+        uint64_t                   write_file_number;
     };
-    ngx_http_tfs_block_info_t              block_info;
-    ngx_uint_t                             ds_retry;
-    ngx_uint_t                             ds_index;
-    ngx_chain_t                           *data;
+    ngx_http_tfs_block_info_t      block_info;
+    ngx_uint_t                     ds_retry;
+    ngx_uint_t                     ds_index;
+    ngx_chain_t                   *data;
 } NGX_PACKED;
 
 
 typedef struct {
-    uint8_t                                still_have;  // for custom file
-    uint32_t                               cluster_id;
-    uint32_t                               open_mode;
-    // not for large_file's data
-    int64_t                                file_offset;
-    uint64_t                               left_length;
-    uint64_t                               file_hole_size;
-    uint32_t                               last_write_segment_index;
-    uint32_t                               segment_index;
-    uint32_t                               segment_count;
-    ngx_http_tfs_segment_data_t           *segment_data;
+    uint8_t                        still_have; /* for custom file */
+    uint32_t                       cluster_id;
+    uint32_t                       open_mode;
+    /* not for large_file's data */
+    int64_t                        file_offset;
+    uint64_t                       left_length;
+    uint64_t                       file_hole_size;
+    uint32_t                       last_write_segment_index;
+    uint32_t                       segment_index;
+    uint32_t                       segment_count;
+    ngx_http_tfs_segment_data_t   *segment_data;
 } NGX_PACKED ngx_http_tfs_file_t;
 
 
 struct  ngx_http_tfs_upstream_s {
-    ngx_str_t                    lock_file;
-    ngx_msec_t                   rcs_interval;
+    ngx_str_t                      lock_file;
+    ngx_msec_t                     rcs_interval;
 
-    ngx_str_t                    rcs_zone_name;
-    ngx_shm_zone_t              *rcs_shm_zone;
-    ngx_http_tfs_rc_ctx_t       *rc_ctx;
+    ngx_str_t                      rcs_zone_name;
+    ngx_shm_zone_t                *rcs_shm_zone;
+    ngx_http_tfs_rc_ctx_t         *rc_ctx;
 
     /* upstream name and port */
-    in_port_t                    port;
-    ngx_str_t                    host;
-    ngx_addr_t                  *ups_addr;
+    in_port_t                      port;
+    ngx_str_t                      host;
+    ngx_addr_t                    *ups_addr;
 
-    struct sockaddr_in           local_addr;
-    u_char                       local_addr_text[NGX_INET_ADDRSTRLEN];
+    struct sockaddr_in             local_addr;
+    u_char                         local_addr_text[NGX_INET_ADDRSTRLEN];
 
-    ngx_flag_t                   enable_rcs;
+    ngx_flag_t                     enable_rcs;
 
-    ngx_http_tfs_timers_data_t  *timer_data;
+    ngx_http_tfs_timers_data_t    *timer_data;
 
-    unsigned                     used:1;
+    unsigned                       used:1;
 };
 
 
 struct  ngx_http_tfs_loc_conf_s {
-    ngx_msec_t                       timeout;
+    ngx_msec_t                     timeout;
 
-    size_t                           max_temp_file_size;
-    size_t                           temp_file_write_size;
+    size_t                         max_temp_file_size;
+    size_t                         temp_file_write_size;
 
-    size_t                           busy_buffers_size_conf;
+    size_t                         busy_buffers_size_conf;
 
-    uint64_t                         meta_root_server;
-    ngx_http_tfs_meta_table_t        meta_server_table;
+    uint64_t                       meta_root_server;
+    ngx_http_tfs_meta_table_t      meta_server_table;
 
-    ngx_http_tfs_upstream_t         *upstream;
+    ngx_http_tfs_upstream_t       *upstream;
 };
 
 
 typedef struct {
 
-    ngx_log_t                       *log;
+    ngx_log_t                     *log;
 } ngx_http_tfs_srv_conf_t;
 
 
 struct  ngx_http_tfs_main_conf_s {
-    ngx_msec_t                             tfs_connect_timeout;
-    ngx_msec_t                             tfs_send_timeout;
-    ngx_msec_t                             tfs_read_timeout;
+    ngx_msec_t                     tfs_connect_timeout;
+    ngx_msec_t                     tfs_send_timeout;
+    ngx_msec_t                     tfs_read_timeout;
 
-    ngx_msec_t                             tair_timeout;
-    ngx_http_tfs_tair_instance_t           dup_instances[NGX_HTTP_TFS_MAX_CLUSTER_COUNT];
+    ngx_msec_t                     tair_timeout;
+    ngx_http_tfs_tair_instance_t   dup_instances[NGX_HTTP_TFS_MAX_CLUSTER_COUNT];
 
-    size_t                                 send_lowat;
-    size_t                                 buffer_size;
-    size_t                                 body_buffer_size;
-    size_t                                 busy_buffers_size;
+    size_t                         send_lowat;
+    size_t                         buffer_size;
+    size_t                         body_buffer_size;
+    size_t                         busy_buffers_size;
 
-    ngx_shm_zone_t                        *block_cache_shm_zone;
+    ngx_shm_zone_t                *block_cache_shm_zone;
 
-    ngx_flag_t                             enable_remote_block_cache;
-    ngx_http_tfs_tair_instance_t           remote_block_cache_instance;
-    ngx_http_tfs_local_block_cache_ctx_t  *local_block_cache_ctx;
+    ngx_flag_t                     enable_remote_block_cache;
+    ngx_http_tfs_tair_instance_t   remote_block_cache_instance;
+    ngx_http_tfs_local_block_cache_ctx_t *local_block_cache_ctx;
 
-    ngx_http_connection_pool_t            *conn_pool;
+    ngx_http_connection_pool_t    *conn_pool;
 
-    uint32_t                               cluster_id;
+    uint32_t                       cluster_id;
 
-    ngx_array_t                            upstreams;
+    ngx_array_t                    upstreams;
 };
 
 
@@ -177,172 +180,173 @@ typedef ngx_int_t (*ngx_http_tfs_sub_process_pt)(ngx_http_tfs_t *t);
 
 
 typedef struct {
-    ngx_list_t                       headers;
+    ngx_list_t                     headers;
 
-    ngx_uint_t                       status_n;
-    ngx_str_t                        status_line;
+    ngx_uint_t                     status_n;
+    ngx_str_t                      status_line;
 
-    ngx_table_elt_t                 *status;
-    ngx_table_elt_t                 *date;
-    ngx_table_elt_t                 *server;
-    ngx_table_elt_t                 *connection;
+    ngx_table_elt_t               *status;
+    ngx_table_elt_t               *date;
+    ngx_table_elt_t               *server;
+    ngx_table_elt_t               *connection;
 
-    ngx_table_elt_t                 *expires;
-    ngx_table_elt_t                 *etag;
-    ngx_table_elt_t                 *x_accel_expires;
-    ngx_table_elt_t                 *x_accel_redirect;
-    ngx_table_elt_t                 *x_accel_limit_rate;
+    ngx_table_elt_t               *expires;
+    ngx_table_elt_t               *etag;
+    ngx_table_elt_t               *x_accel_expires;
+    ngx_table_elt_t               *x_accel_redirect;
+    ngx_table_elt_t               *x_accel_limit_rate;
 
-    ngx_table_elt_t                 *content_type;
-    ngx_table_elt_t                 *content_length;
+    ngx_table_elt_t               *content_type;
+    ngx_table_elt_t               *content_length;
 
-    ngx_table_elt_t                 *last_modified;
-    ngx_table_elt_t                 *location;
-    ngx_table_elt_t                 *accept_ranges;
-    ngx_table_elt_t                 *www_authenticate;
+    ngx_table_elt_t               *last_modified;
+    ngx_table_elt_t               *location;
+    ngx_table_elt_t               *accept_ranges;
+    ngx_table_elt_t               *www_authenticate;
 
 #if (NGX_HTTP_GZIP)
-    ngx_table_elt_t                 *content_encoding;
+    ngx_table_elt_t               *content_encoding;
 #endif
 
-    off_t                            content_length_n;
+    off_t                          content_length_n;
 
-    ngx_array_t                      cache_control;
+    ngx_array_t                    cache_control;
 } ngx_http_tfs_headers_in_t;
 
 
 struct ngx_http_tfs_s {
-    ngx_http_tfs_handler_pt           read_event_handler;
-    ngx_http_tfs_handler_pt           write_event_handler;
+    ngx_http_tfs_handler_pt        read_event_handler;
+    ngx_http_tfs_handler_pt        write_event_handler;
 
-    ngx_http_tfs_peer_connection_t   *tfs_peer;
-    ngx_http_tfs_peer_connection_t   *tfs_peer_servers;
-    uint8_t                           tfs_peer_count;
+    ngx_http_tfs_peer_connection_t *tfs_peer;
+    ngx_http_tfs_peer_connection_t *tfs_peer_servers;
+    uint8_t                       tfs_peer_count;
 
-    ngx_http_tfs_loc_conf_t          *loc_conf;
-    ngx_http_tfs_srv_conf_t          *srv_conf;
-    ngx_http_tfs_main_conf_t         *main_conf;
+    ngx_http_tfs_loc_conf_t       *loc_conf;
+    ngx_http_tfs_srv_conf_t       *srv_conf;
+    ngx_http_tfs_main_conf_t      *main_conf;
 
-    ngx_http_tfs_restful_ctx_t        r_ctx;
+    ngx_http_tfs_restful_ctx_t     r_ctx;
 
-    ngx_output_chain_ctx_t            output;
-    ngx_chain_writer_ctx_t            writer;
+    ngx_output_chain_ctx_t         output;
+    ngx_chain_writer_ctx_t         writer;
 
-    ngx_chain_t                      *request_bufs;
-    ngx_chain_t                      *send_body;
-    ngx_pool_t                       *pool;
+    ngx_chain_t                   *request_bufs;
+    ngx_chain_t                   *send_body;
+    ngx_pool_t                    *pool;
 
-    ngx_buf_t                         header_buffer;
+    ngx_buf_t                      header_buffer;
 
-    ngx_chain_t                      *recv_chain;
+    ngx_chain_t                   *recv_chain;
 
-    ngx_chain_t                      *out_bufs;
-    ngx_chain_t                      *busy_bufs;
-    ngx_chain_t                      *free_bufs;
+    ngx_chain_t                   *out_bufs;
+    ngx_chain_t                   *busy_bufs;
+    ngx_chain_t                   *free_bufs;
 
-    ngx_http_tfs_rcs_info_t          *rc_info_node;
-    ngx_rbtree_node_t                *node;
+    ngx_http_tfs_rcs_info_t       *rc_info_node;
+    ngx_rbtree_node_t             *node;
 
-    ngx_uint_t                        logical_cluster_index;
-    ngx_uint_t                        rw_cluster_index;
+    ngx_uint_t                     logical_cluster_index;
+    ngx_uint_t                     rw_cluster_index;
 
     /* keep alive */
-    ngx_queue_t                      *curr_ka_queue;
+    ngx_queue_t                   *curr_ka_queue;
 
     /* header pointer */
-    void                             *header;
-    ngx_int_t                         header_size;
+    void                          *header;
+    ngx_int_t                      header_size;
 
-    tfs_peer_handler_pt               create_request;
-    tfs_peer_handler_pt               input_filter;
-    tfs_peer_handler_pt               retry_handler;
-    tfs_peer_handler_pt               process_request_body;
-    tfs_peer_handler_pt               finalize_request;
+    tfs_peer_handler_pt            create_request;
+    tfs_peer_handler_pt            input_filter;
+    tfs_peer_handler_pt            retry_handler;
+    tfs_peer_handler_pt            process_request_body;
+    tfs_peer_handler_pt            finalize_request;
+    tfs_peer_handler_pt            decline_handler;
 
-    void                             *finalize_data;
-    void                             *data;
+    void                          *finalize_data;
+    void                          *data;
 
-    ngx_int_t                         request_sent;
-    ngx_uint_t                        sent_size;
-    off_t                             length;
+    ngx_int_t                      request_sent;
+    ngx_uint_t                     sent_size;
+    off_t                          length;
 
-    ngx_log_t                        *log;
+    ngx_log_t                     *log;
 
-    ngx_int_t                         parse_state;
+    ngx_int_t                      parse_state;
 
     /* final file name */
-    ngx_str_t                         file_name;
+    ngx_str_t                      file_name;
 
-    ngx_int_t                         state;
+    ngx_int_t                      state;
 
     /* custom file */
-    ngx_http_tfs_custom_meta_info_t   meta_info;
-    ngx_str_t                         last_file_path;
-    int64_t                           last_file_pid;
-    uint8_t                           last_file_type;
-    ngx_int_t                        *dir_lens;
-    ngx_int_t                         last_dir_level;
-    uint16_t                          orig_action;
-    ngx_array_t                       file_holes;
+    ngx_http_tfs_custom_meta_info_t meta_info;
+    ngx_str_t                      last_file_path;
+    int64_t                        last_file_pid;
+    uint8_t                        last_file_type;
+    ngx_int_t                     *dir_lens;
+    ngx_int_t                      last_dir_level;
+    uint16_t                       orig_action;
+    ngx_array_t                    file_holes;
 
-    ngx_http_tfs_headers_in_t         headers_in;
+    ngx_http_tfs_headers_in_t      headers_in;
 
     /* delete */
-    ngx_int_t                         group_count;
-    ngx_int_t                         group_seq;
+    ngx_int_t                      group_count;
+    ngx_int_t                      group_seq;
 
     /* name ip */
-    ngx_http_tfs_inet_t               name_server_addr;
-    ngx_str_t                         name_server_addr_text;
+    ngx_http_tfs_inet_t            name_server_addr;
+    ngx_str_t                      name_server_addr_text;
 
-    ngx_http_tfs_json_gen_t          *json_output;
+    ngx_http_tfs_json_gen_t       *json_output;
 
-    ngx_uint_t                        status;
-    ngx_str_t                         status_line;
-    ngx_int_t                         tfs_status;
+    ngx_uint_t                     status;
+    ngx_str_t                      status_line;
+    ngx_int_t                      tfs_status;
 
-    uint64_t                          output_size;
+    uint64_t                       output_size;
 
     /* de-duplicate info */
-    ngx_http_tfs_dedup_ctx_t          dedup_ctx;
+    ngx_http_tfs_dedup_ctx_t       dedup_ctx;
 
     /* stat info */
-    ngx_http_tfs_stat_info_t          stat_info;
+    ngx_http_tfs_stat_info_t       stat_info;
 
     /* file info */
-    ngx_chain_t                      *meta_segment_data;
-    ngx_http_tfs_file_t               file;
-    ngx_http_tfs_segment_head_t      *seg_head;
-    ngx_http_tfs_raw_file_info_t      file_info;
-    ngx_buf_t                        *readv2_rsp_tail_buf;
-    uint8_t                           read_ver;
+    ngx_chain_t                   *meta_segment_data;
+    ngx_http_tfs_file_t            file;
+    ngx_http_tfs_segment_head_t   *seg_head;
+    ngx_http_tfs_raw_file_info_t   file_info;
+    ngx_buf_t                     *readv2_rsp_tail_buf;
+    uint8_t                        read_ver;
 
     /* block cache */
-    ngx_http_tfs_block_cache_ctx_t    block_cache_ctx;
+    ngx_http_tfs_block_cache_ctx_t block_cache_ctx;
 
     /* for parallel write segments */
-    ngx_http_tfs_t                   *parent;
-    ngx_http_tfs_t                   *next;
-    ngx_http_tfs_t                   *free_sts;
-    ngx_http_tfs_sub_process_pt       sp_callback;
-    uint32_t                          sp_count;
-    uint32_t                          sp_done_count;
-    uint32_t                          sp_fail_count;
-    uint32_t                          sp_succ_count;
-    uint32_t                          sp_curr;
-    unsigned                          sp_ready:1;
+    ngx_http_tfs_t                *parent;
+    ngx_http_tfs_t                *next;
+    ngx_http_tfs_t                *free_sts;
+    ngx_http_tfs_sub_process_pt    sp_callback;
+    uint32_t                       sp_count;
+    uint32_t                       sp_done_count;
+    uint32_t                       sp_fail_count;
+    uint32_t                       sp_succ_count;
+    uint32_t                       sp_curr;
+    unsigned                       sp_ready:1;
 
-    unsigned                          header_only:1;
-    unsigned                          header_sent:1;
-    unsigned                          has_split_frag:1;
+    unsigned                       header_only:1;
+    unsigned                       has_split_frag:1;
     /* for custrom file read */
-    unsigned                          is_first_segment:1;
+    unsigned                       is_first_segment:1;
 
-    unsigned                          use_dedup:1;
-    unsigned                          is_stat_dup_file:1;
-    unsigned                          is_large_file:1;
-    unsigned                          is_process_meta_seg:1;
-    unsigned                          retry_curr_ns:1;
+    unsigned                       use_dedup:1;
+    unsigned                       is_stat_dup_file:1;
+    unsigned                       is_large_file:1;
+    unsigned                       is_process_meta_seg:1;
+    unsigned                       retry_curr_ns:1;
+    unsigned                       request_timeout:1;
 };
 
 
@@ -352,19 +356,25 @@ void ngx_http_tfs_finalize_request(ngx_http_request_t *r,
 void ngx_http_tfs_finalize_state(ngx_http_tfs_t *t, ngx_int_t rc);
 ngx_int_t ngx_http_tfs_reinit(ngx_http_request_t *r, ngx_http_tfs_t *t);
 ngx_int_t ngx_http_tfs_connect(ngx_http_tfs_t *t);
-ngx_int_t ngx_http_tfs_lookup_block_cache(ngx_http_tfs_t *t,
-    ngx_http_tfs_segment_data_t *segment_data);
+/* block cache related */
+ngx_int_t ngx_http_tfs_lookup_block_cache(ngx_http_tfs_t *t);
 ngx_int_t ngx_http_tfs_batch_lookup_block_cache(ngx_http_tfs_t *t);
 void ngx_http_tfs_remove_block_cache(ngx_http_tfs_t *t,
     ngx_http_tfs_segment_data_t *segment_data);
+
 ngx_int_t ngx_http_tfs_set_output_appid(ngx_http_tfs_t *t, uint64_t app_id);
 void ngx_http_tfs_set_custom_initial_parameters(ngx_http_tfs_t *t);
 ngx_int_t ngx_http_tfs_misc_ctx_init(ngx_http_tfs_t *t,
     ngx_http_tfs_rcs_info_t *rc_node);
+
+/* dedup related */
+ngx_int_t ngx_http_tfs_get_duplicate_info(ngx_http_tfs_t *t);
+ngx_int_t ngx_http_tfs_set_duplicate_info(ngx_http_tfs_t *t);
+
+/* sub process related */
 ngx_int_t ngx_http_tfs_batch_process_start(ngx_http_tfs_t *t);
 ngx_int_t ngx_http_tfs_batch_process_end(ngx_http_tfs_t *t);
 ngx_int_t ngx_http_tfs_batch_process_next(ngx_http_tfs_t *t);
 
 
 #endif /* _NGX_TFS_H_INCLUDED_ */
-

--- a/src/ngx_http_tfs_block_cache.c
+++ b/src/ngx_http_tfs_block_cache.c
@@ -15,7 +15,7 @@ ngx_http_tfs_block_cache_lookup(ngx_http_tfs_block_cache_ctx_t *ctx,
     ngx_pool_t *pool, ngx_log_t *log, ngx_http_tfs_block_cache_key_t *key,
     ngx_http_tfs_block_cache_value_t *value)
 {
-    ngx_int_t   rc = NGX_DECLINED;
+    ngx_int_t  rc = NGX_DECLINED;
 
     if (ctx->curr_lookup_cache == NGX_HTTP_TFS_LOCAL_BLOCK_CACHE) {
 
@@ -84,13 +84,13 @@ ngx_http_tfs_block_cache_batch_lookup(ngx_http_tfs_block_cache_ctx_t *ctx,
     ngx_pool_t *pool, ngx_log_t *log, ngx_array_t *keys,
     ngx_array_t *kvs)
 {
-    uint32_t                           i;
-    ngx_int_t                          rc;
-    ngx_uint_t                         local_miss_count;
-    ngx_array_t                        local_miss_keys;
-    ngx_http_tfs_t                    *t;
-    ngx_http_tfs_segment_data_t       *segment_data;
-    ngx_http_tfs_block_cache_key_t    *key;
+    uint32_t                        i;
+    ngx_int_t                       rc;
+    ngx_uint_t                      local_miss_count;
+    ngx_array_t                     local_miss_keys;
+    ngx_http_tfs_t                 *t;
+    ngx_http_tfs_segment_data_t    *segment_data;
+    ngx_http_tfs_block_cache_key_t *key;
 
     rc = NGX_DECLINED;
 
@@ -139,6 +139,7 @@ ngx_http_tfs_block_cache_batch_lookup(ngx_http_tfs_block_cache_ctx_t *ctx,
                                                               &local_miss_keys);
         }
     }
+
     return rc;
 }
 
@@ -148,16 +149,21 @@ ngx_http_tfs_block_cache_cmp(ngx_http_tfs_block_cache_key_t *left,
     ngx_http_tfs_block_cache_key_t *right)
 {
     if (left->ns_addr == right->ns_addr) {
+
         if (left->block_id == right->block_id) {
             return 0;
         }
+
         if (left->block_id < right->block_id) {
             return -1;
         }
+
         return 1;
     }
+
     if (left->ns_addr < right->ns_addr) {
         return -1;
     }
+
     return 1;
 }

--- a/src/ngx_http_tfs_block_cache.h
+++ b/src/ngx_http_tfs_block_cache.h
@@ -12,8 +12,7 @@
 #include <ngx_http_tfs_tair_helper.h>
 
 
-#define NGX_HTTP_TFS_BLOCK_CACHE_KEY_SIZE       \
-    sizeof(ngx_http_tfs_block_cache_key_t)
+#define NGX_HTTP_TFS_BLOCK_CACHE_KEY_SIZE sizeof(ngx_http_tfs_block_cache_key_t)
 
 #define NGX_HTTP_TFS_REMOTE_BLOCK_CACHE_VALUE_BASE_SIZE sizeof(uint32_t)
 
@@ -27,50 +26,50 @@
 
 
 typedef struct {
-    uint64_t                                ns_addr;
-    uint32_t                                block_id;
+    uint64_t                             ns_addr;
+    uint32_t                             block_id;
 } __attribute__ ((__packed__)) ngx_http_tfs_block_cache_key_t;
 
 
 typedef struct {
-    uint32_t                                ds_count;
-    uint64_t                               *ds_addrs;
+    uint32_t                             ds_count;
+    uint64_t                            *ds_addrs;
 } ngx_http_tfs_block_cache_value_t;
 
 
 typedef struct {
-    ngx_http_tfs_block_cache_key_t         *key;
-    ngx_http_tfs_block_cache_value_t       *value;
+    ngx_http_tfs_block_cache_key_t      *key;
+    ngx_http_tfs_block_cache_value_t    *value;
 } ngx_http_tfs_block_cache_kv_t;
 
 
 typedef struct {
-    ngx_rbtree_t                            rbtree;
-    ngx_rbtree_node_t                       sentinel;
-    ngx_queue_t                             queue;
-    uint64_t                                discard_item_count;
-    uint64_t                                hit_count;
-    uint64_t                                miss_count;
+    ngx_rbtree_t                         rbtree;
+    ngx_rbtree_node_t                    sentinel;
+    ngx_queue_t                          queue;
+    uint64_t                             discard_item_count;
+    uint64_t                             hit_count;
+    uint64_t                             miss_count;
 } ngx_http_tfs_block_cache_shctx_t;
 
 
 typedef struct {
-    ngx_http_tfs_block_cache_shctx_t       *sh;
-    ngx_slab_pool_t                        *shpool;
+    ngx_http_tfs_block_cache_shctx_t    *sh;
+    ngx_slab_pool_t                     *shpool;
 } ngx_http_tfs_local_block_cache_ctx_t;
 
 
 typedef struct {
-    void                                   *data;
-    ngx_http_tfs_tair_instance_t           *tair_instance;
+    void                                *data;
+    ngx_http_tfs_tair_instance_t        *tair_instance;
 } ngx_http_tfs_remote_block_cache_ctx_t;
 
 
 typedef struct {
-    ngx_http_tfs_local_block_cache_ctx_t   *local_ctx;
-    ngx_http_tfs_remote_block_cache_ctx_t   remote_ctx;
-    uint8_t                                 use_cache;
-    uint8_t                                 curr_lookup_cache;
+    ngx_http_tfs_local_block_cache_ctx_t *local_ctx;
+    ngx_http_tfs_remote_block_cache_ctx_t remote_ctx;
+    uint8_t                               use_cache;
+    uint8_t                               curr_lookup_cache;
 } ngx_http_tfs_block_cache_ctx_t;
 
 

--- a/src/ngx_http_tfs_data_server_message.c
+++ b/src/ngx_http_tfs_data_server_message.c
@@ -44,7 +44,7 @@ ngx_http_tfs_inet_t *
 ngx_http_tfs_select_data_server(ngx_http_tfs_t *t,
     ngx_http_tfs_segment_data_t *segment_data)
 {
-    ngx_http_tfs_block_info_t     *block_info;
+    ngx_http_tfs_block_info_t  *block_info;
 
     block_info = &segment_data->block_info;
 
@@ -59,6 +59,7 @@ ngx_http_tfs_select_data_server(ngx_http_tfs_t *t,
             }
         }
         break;
+
     case NGX_HTTP_TFS_ACTION_WRITE_FILE:
     case NGX_HTTP_TFS_ACTION_REMOVE_FILE:
         if (t->is_stat_dup_file) {
@@ -92,12 +93,12 @@ ngx_http_tfs_select_data_server(ngx_http_tfs_t *t,
 ngx_chain_t *
 ngx_http_tfs_data_server_create_message(ngx_http_tfs_t *t)
 {
-    int32_t                           meta_segment_size;
-    uint16_t                          action;
-    ngx_int_t                         rc;
-    ngx_buf_t                        *b;
-    ngx_chain_t                      *cl;
-    ngx_http_tfs_segment_data_t      *segment_data;
+    int32_t                       meta_segment_size;
+    uint16_t                      action;
+    ngx_int_t                     rc;
+    ngx_buf_t                    *b;
+    ngx_chain_t                  *cl;
+    ngx_http_tfs_segment_data_t  *segment_data;
 
     cl = NULL;
     meta_segment_size = 0;
@@ -140,7 +141,8 @@ ngx_http_tfs_data_server_create_message(ngx_http_tfs_t *t)
             }
         }
 
-        /* use readv2 to get file size if we do not know that */
+        /* use readv2 to get file size if we do not know
+         * readv2 require read offset is 0 */
         if (t->r_ctx.version == 1
             && t->file.left_length == NGX_HTTP_TFS_MAX_SIZE
             && t->file.file_offset == 0)
@@ -172,6 +174,7 @@ ngx_http_tfs_data_server_create_message(ngx_http_tfs_t *t)
         default:
             return NULL;
         }
+
     case NGX_HTTP_TFS_ACTION_REMOVE_FILE:
         switch(t->state) {
         case NGX_HTTP_TFS_STATE_REMOVE_STAT_FILE:
@@ -185,7 +188,8 @@ ngx_http_tfs_data_server_create_message(ngx_http_tfs_t *t)
                     t->file.left_length = t->file_info.size;
                 }
                 /* if is large file, for files smaller than 140GB,
-                 * 2MB is fairly enough */
+                 * 2MB is fairly enough
+                 */
                 if (t->is_large_file) {
                     meta_segment_size = NGX_HTTP_TFS_MAX_FRAGMENT_SIZE;
                     t->file.left_length = NGX_HTTP_TFS_MAX_SIZE;
@@ -219,6 +223,7 @@ ngx_http_tfs_data_server_create_message(ngx_http_tfs_t *t)
                                      t->read_ver, NGX_HTTP_TFS_READ_STAT_FORCE);
         case NGX_HTTP_TFS_STATE_REMOVE_DELETE_DATA:
             return ngx_http_tfs_create_unlink_message(t, segment_data);
+
         default:
             return NULL;
         }
@@ -231,15 +236,17 @@ ngx_http_tfs_data_server_create_message(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_data_server_parse_message(ngx_http_tfs_t *t)
 {
-    ngx_http_tfs_segment_data_t      *segment_data;
+    ngx_http_tfs_segment_data_t  *segment_data;
 
     segment_data = &t->file.segment_data[t->file.segment_index];
 
     switch (t->r_ctx.action.code) {
     case NGX_HTTP_TFS_ACTION_READ_FILE:
         return ngx_http_tfs_parse_read_message(t);
+
     case NGX_HTTP_TFS_ACTION_STAT_FILE:
         return ngx_http_tfs_parse_statfile_message(t, segment_data);
+
     case NGX_HTTP_TFS_ACTION_WRITE_FILE:
         switch(t->state) {
         case NGX_HTTP_TFS_STATE_WRITE_STAT_DUP_FILE:
@@ -253,6 +260,7 @@ ngx_http_tfs_data_server_parse_message(ngx_http_tfs_t *t)
         default:
             return NGX_ERROR;
         }
+
     case NGX_HTTP_TFS_ACTION_REMOVE_FILE:
         switch(t->state) {
         case NGX_HTTP_TFS_STATE_REMOVE_STAT_FILE:
@@ -274,10 +282,10 @@ static ngx_chain_t *
 ngx_http_tfs_create_createfile_message(ngx_http_tfs_t *t,
     ngx_http_tfs_segment_data_t *segment_data)
 {
-    size_t                                     size;
-    ngx_buf_t                                 *b;
-    ngx_chain_t                               *cl;
-    ngx_http_tfs_ds_msg_header_t              *req;
+    size_t                         size;
+    ngx_buf_t                     *b;
+    ngx_chain_t                   *cl;
+    ngx_http_tfs_ds_msg_header_t  *req;
 
     size = sizeof(ngx_http_tfs_ds_msg_header_t);
 
@@ -317,16 +325,16 @@ static ngx_chain_t *
 ngx_http_tfs_create_write_message(ngx_http_tfs_t *t,
     ngx_http_tfs_segment_data_t *segment_data)
 {
-    u_char                                    *p, exit;
-    size_t                                     size, body_size, b_size;
-    uint32_t                                   crc;
-    ngx_int_t                                  rc;
-    ngx_buf_t                                 *b;
-    ngx_uint_t                                 i;
-    ngx_chain_t                               *cl, *body, *ch;
-    ngx_http_tfs_crc_t                         t_crc;
-    ngx_http_tfs_block_info_t                 *block_info;
-    ngx_http_tfs_ds_write_request_t           *req;
+    u_char                           *p, exit;
+    size_t                            size, body_size, b_size;
+    uint32_t                          crc;
+    ngx_int_t                         rc;
+    ngx_buf_t                        *b;
+    ngx_uint_t                        i;
+    ngx_chain_t                      *cl, *body, *ch;
+    ngx_http_tfs_crc_t                t_crc;
+    ngx_http_tfs_block_info_t        *block_info;
+    ngx_http_tfs_ds_write_request_t  *req;
 
     exit = 0;
 
@@ -397,7 +405,8 @@ ngx_http_tfs_create_write_message(ngx_http_tfs_t *t,
     t_crc.data_crc = segment_data->segment_info.crc;
 
     /* body buf is one or two bufs,
-     * please see ngx_http_read_client_request_body */
+     * please see ngx_http_read_client_request_body
+     */
     while (body) {
         b_size = ngx_buf_size(body->buf);
         body_size += b_size;
@@ -445,7 +454,8 @@ ngx_http_tfs_create_write_message(ngx_http_tfs_t *t,
                   segment_data->segment_info.file_id, req->offset,
                   req->length, t_crc.data_crc);
 
-    segment_data->segment_info.crc = t_crc.data_crc;
+    /* save here to update segment_info->crc after write success */
+    segment_data->curr_crc = t_crc.data_crc;
     req->header.base_header.len = size - sizeof(ngx_http_tfs_header_t)
                                    + req->length;
     req->header.base_header.crc = t_crc.crc;
@@ -458,13 +468,13 @@ static ngx_chain_t *
 ngx_http_tfs_create_closefile_message(ngx_http_tfs_t *t,
     ngx_http_tfs_segment_data_t *segment_data)
 {
-    u_char                                    *p;
-    size_t                                     size;
-    ngx_buf_t                                 *b;
-    ngx_uint_t                                 i;
-    ngx_chain_t                               *cl;
-    ngx_http_tfs_block_info_t                 *block_info;
-    ngx_http_tfs_ds_close_request_t           *req;
+    u_char                           *p;
+    size_t                            size;
+    ngx_buf_t                        *b;
+    ngx_uint_t                        i;
+    ngx_chain_t                      *cl;
+    ngx_http_tfs_block_info_t        *block_info;
+    ngx_http_tfs_ds_close_request_t  *req;
 
     block_info = &segment_data->block_info;
     size = sizeof(ngx_http_tfs_ds_close_request_t) +
@@ -548,10 +558,10 @@ ngx_http_tfs_create_read_message(ngx_http_tfs_t *t,
     ngx_http_tfs_segment_data_t *segment_data, uint8_t read_ver,
     uint8_t read_flag)
 {
-    size_t                                     size;
-    ngx_buf_t                                 *b;
-    ngx_chain_t                               *cl;
-    ngx_http_tfs_ds_read_request_t            *req;
+    size_t                           size;
+    ngx_buf_t                       *b;
+    ngx_chain_t                     *cl;
+    ngx_http_tfs_ds_read_request_t  *req;
 
     size = sizeof(ngx_http_tfs_ds_read_request_t);
 
@@ -606,13 +616,13 @@ static ngx_chain_t *
 ngx_http_tfs_create_unlink_message(ngx_http_tfs_t *t,
     ngx_http_tfs_segment_data_t *segment_data)
 {
-    u_char                                    *p;
-    size_t                                     size;
-    ngx_buf_t                                 *b;
-    ngx_uint_t                                 i;
-    ngx_chain_t                               *cl;
-    ngx_http_tfs_block_info_t                 *block_info;
-    ngx_http_tfs_ds_unlink_request_t          *req;
+    u_char                            *p;
+    size_t                             size;
+    ngx_buf_t                         *b;
+    ngx_uint_t                         i;
+    ngx_chain_t                       *cl;
+    ngx_http_tfs_block_info_t         *block_info;
+    ngx_http_tfs_ds_unlink_request_t  *req;
 
     block_info = &segment_data->block_info;
     size = sizeof(ngx_http_tfs_ds_unlink_request_t) +
@@ -782,9 +792,9 @@ ngx_http_tfs_parse_createfile_message(ngx_http_tfs_t *t,
 static ngx_int_t
 ngx_http_tfs_parse_write_message(ngx_http_tfs_t *t)
 {
-    uint16_t                                  type;
-    ngx_str_t                                 action;
-    ngx_http_tfs_header_t                    *header;
+    uint16_t                type;
+    ngx_str_t               action;
+    ngx_http_tfs_header_t  *header;
 
     header = (ngx_http_tfs_header_t *) t->header;
     type = header->type;
@@ -807,9 +817,9 @@ ngx_http_tfs_parse_write_message(ngx_http_tfs_t *t)
 static ngx_int_t
 ngx_http_tfs_parse_closefile_message(ngx_http_tfs_t *t)
 {
-    uint16_t                                  type;
-    ngx_str_t                                 action;
-    ngx_http_tfs_header_t                    *header;
+    uint16_t                type;
+    ngx_str_t               action;
+    ngx_http_tfs_header_t  *header;
 
     header = (ngx_http_tfs_header_t *) t->header;
     type = header->type;
@@ -833,14 +843,15 @@ ngx_http_tfs_parse_closefile_message(ngx_http_tfs_t *t)
 static ngx_int_t
 ngx_http_tfs_parse_read_message(ngx_http_tfs_t *t)
 {
-    size_t                                    size, left_len, tail_len;
-    uint16_t                                  type;
-    ngx_int_t                                 rc;
-    ngx_str_t                                 err_msg;
-    ngx_buf_t                                *b;
-    ngx_http_tfs_peer_connection_t           *tp;
-    ngx_http_tfs_ds_read_response_t          *resp;
-    ngx_http_tfs_ds_readv2_response_tail_t   *readv2_rsp_tail;
+    size_t                                   size, left_len, tail_len;
+    int32_t                                  code, err_len;
+    uint16_t                                 type;
+    ngx_int_t                                rc;
+    ngx_str_t                                err_msg;
+    ngx_buf_t                               *b;
+    ngx_http_tfs_peer_connection_t          *tp;
+    ngx_http_tfs_ds_read_response_t         *resp;
+    ngx_http_tfs_ds_readv2_response_tail_t  *readv2_rsp_tail;
 
     resp = (ngx_http_tfs_ds_read_response_t *) t->header;
     tp = t->tfs_peer;
@@ -849,8 +860,22 @@ ngx_http_tfs_parse_read_message(ngx_http_tfs_t *t)
 
     switch (type) {
     case NGX_HTTP_TFS_STATUS_MESSAGE:
-        ngx_str_set(&err_msg, "read data (data server)");
-        return ngx_http_tfs_status_message(&tp->body_buffer, &err_msg, t->log);
+        /* weird status message, err_code is in resp->data_len */
+        code = resp->data_len;
+        if (code != NGX_HTTP_TFS_STATUS_MESSAGE_OK) {
+            err_len = *(uint32_t*) (b->pos);
+            if (err_len > 0) {
+                err_msg.data = b->pos + sizeof(uint32_t);
+                err_msg.len = err_len;
+            }
+
+            ngx_log_error(NGX_LOG_ERR, t->log, 0,
+                          "read data (data server: %s) failed, "
+                          "error code (%d) err_msg(%V)",
+                          tp->peer_addr_text, code, &err_msg);
+        }
+
+        return NGX_HTTP_TFS_AGAIN;
     }
 
     size = ngx_buf_size(b);
@@ -1010,13 +1035,13 @@ static ngx_int_t
 ngx_http_tfs_parse_statfile_message(ngx_http_tfs_t *t,
     ngx_http_tfs_segment_data_t *segment_data)
 {
-    uint16_t                                type;
-    ngx_int_t                               rc;
-    ngx_str_t                               action;
-    ngx_http_tfs_header_t                  *header;
-    ngx_http_tfs_peer_connection_t         *tp;
-    ngx_http_tfs_ds_stat_response_t        *resp;
-    ngx_http_tfs_ds_sp_readv2_response_t   *resp2;
+    uint16_t                               type;
+    ngx_int_t                              rc;
+    ngx_str_t                              action;
+    ngx_http_tfs_header_t                 *header;
+    ngx_http_tfs_peer_connection_t        *tp;
+    ngx_http_tfs_ds_stat_response_t       *resp;
+    ngx_http_tfs_ds_sp_readv2_response_t  *resp2;
 
 
     header = (ngx_http_tfs_header_t *) t->header;
@@ -1150,17 +1175,17 @@ ngx_http_tfs_set_meta_segment_data(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_parse_meta_segment(ngx_http_tfs_t *t, ngx_chain_t *data)
 {
-    ssize_t                              n;
-    uint64_t                             data_size;
-    uint32_t                             i, segment_count;
-    ngx_buf_t                           *b, *tmp_b;
-    ngx_int_t                            rc;
-    ngx_str_t                            tfs_name;
-    ngx_chain_t                         *body, *cl;
-    ngx_http_tfs_raw_fsname_t            fsname;
-    ngx_http_tfs_segment_head_t         *seg_head;
-    ngx_http_tfs_segment_info_t         *seg_info;
-    ngx_http_tfs_tmp_segment_info_t     *tmp_seg_info;
+    ssize_t                           n;
+    uint64_t                          data_size;
+    uint32_t                          i, segment_count;
+    ngx_buf_t                        *b, *tmp_b;
+    ngx_int_t                         rc;
+    ngx_str_t                         tfs_name;
+    ngx_chain_t                      *body, *cl;
+    ngx_http_tfs_raw_fsname_t         fsname;
+    ngx_http_tfs_segment_head_t      *seg_head;
+    ngx_http_tfs_segment_info_t      *seg_info;
+    ngx_http_tfs_tmp_segment_info_t  *tmp_seg_info;
 
     if (data == NULL || t->meta_segment_data != NULL) {
         return NGX_ERROR;
@@ -1251,13 +1276,16 @@ ngx_http_tfs_parse_meta_segment(ngx_http_tfs_t *t, ngx_chain_t *data)
 }
 
 
-/* use binary search to find the segment we need */
-/* if found, return index, or return index to insert */
+/*
+ * We use binary search to find the segment we need
+ * if found, return index, or return index to insert.
+ */
+
 ngx_int_t
 ngx_http_tfs_find_segment(ngx_int_t seg_count,
     ngx_http_tfs_segment_info_t *seg_info, int64_t offset)
 {
-    ngx_int_t         start, end, middle;
+    ngx_int_t  start, end, middle;
 
     start = 0;
     end = seg_count - 1;
@@ -1360,8 +1388,10 @@ ngx_http_tfs_get_segment_for_read(ngx_http_tfs_t *t)
     first_segment->oper_size =
         first_segment->segment_info.size - first_segment->oper_offset;
 
-    /* last segment's oper_size is special,
-     * notice that last_segment maybe the same as first_semgnt */
+    /*
+     * last segment's oper_size is special,
+     * notice that last_segment maybe the same as first_semgnt
+     */
     last_segment = &t->file.segment_data[seg_count - 1];
     last_segment->oper_size = ngx_min((end_offset
                                        - (last_segment->segment_info.offset
@@ -1384,12 +1414,12 @@ ngx_http_tfs_get_segment_for_read(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_get_segment_for_write(ngx_http_tfs_t *t)
 {
-    size_t                        data_size, buf_size, size;
-    int64_t                       offset;
-    uint32_t                      left_size;
-    ngx_int_t                     seg_count, i;
-    ngx_buf_t                    *b;
-    ngx_chain_t                  *body, *cl, **ll;
+    size_t        data_size, buf_size, size;
+    int64_t       offset;
+    uint32_t      left_size;
+    ngx_uint_t    seg_count, i;
+    ngx_buf_t    *b;
+    ngx_chain_t  *body, *cl, **ll;
 
     if (t->send_body == NULL) {
         return NGX_ERROR;
@@ -1398,8 +1428,10 @@ ngx_http_tfs_get_segment_for_write(ngx_http_tfs_t *t)
     body = t->send_body;
     offset = 0;
 
-    /* body buf is one or two bufs ,
-     * please see ngx_http_read_client_request_body */
+    /*
+     * body buf is one or two bufs ,
+     * please see ngx_http_read_client_request_body
+     */
     data_size = ngx_http_tfs_get_chain_buf_size(body);
     t->file.left_length = data_size;
 
@@ -1444,6 +1476,7 @@ ngx_http_tfs_get_segment_for_write(ngx_http_tfs_t *t)
         ll = &t->file.segment_data[i].data;
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, t->log, 0,
                       "prepare segment[%i]'s data", i);
+
         while (left_size > 0) {
             while (body && ngx_buf_size(body->buf) == 0) {
                 ngx_log_debug0(NGX_LOG_DEBUG_HTTP, t->log, 0,
@@ -1505,7 +1538,7 @@ ngx_http_tfs_get_segment_for_write(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_get_segment_for_delete(ngx_http_tfs_t *t)
 {
-    ngx_int_t                     seg_count, i;
+    ngx_uint_t                    seg_count, i;
     ngx_buf_t                    *b;
     ngx_http_tfs_segment_info_t  *seg_info;
 
@@ -1544,7 +1577,7 @@ ngx_http_tfs_copy_body_buffer(ngx_http_tfs_t *t, ssize_t bytes, u_char *body)
 {
     ngx_http_request_t  *r = t->data;
 
-    ngx_chain_t          *cl, **ll;
+    ngx_chain_t  *cl, **ll;
 
     for (cl = t->out_bufs, ll = &t->out_bufs; cl; cl = cl->next) {
         ll = &cl->next;
@@ -1571,10 +1604,9 @@ ngx_http_tfs_copy_body_buffer(ngx_http_tfs_t *t, ssize_t bytes, u_char *body)
 ngx_int_t
 ngx_http_tfs_fill_file_hole(ngx_http_tfs_t *t, size_t file_hole_size)
 {
-    size_t                                    size;
-    ngx_int_t                                 rc;
-    ngx_buf_t                                *b;
-    ngx_buf_t                                *zero_buf;
+    size_t     size;
+    ngx_int_t  rc;
+    ngx_buf_t  *b, *zero_buf;
 
     b = &t->tfs_peer_servers[NGX_HTTP_TFS_DATA_SERVER].body_buffer;
     if (b->start == NULL) {

--- a/src/ngx_http_tfs_duplicate.h
+++ b/src/ngx_http_tfs_duplicate.h
@@ -21,16 +21,17 @@ typedef struct {
     ngx_buf_t                         save_body_buffer;
     ngx_http_tfs_t                   *data;
     ngx_http_tfs_tair_instance_t     *tair_instance;
+    ngx_chain_t                      *file_data;
     unsigned                          md5_sumed:1;
 } ngx_http_tfs_dedup_ctx_t;
 
 
-ngx_int_t ngx_http_tfs_get_duplicate_info(ngx_http_tfs_dedup_ctx_t *ctx,
-    ngx_pool_t *pool, ngx_log_t *log, ngx_chain_t *data);
-ngx_int_t ngx_http_tfs_set_duplicate_info(ngx_http_tfs_dedup_ctx_t *ctx,
-    ngx_pool_t *pool, ngx_log_t *log, ngx_chain_t *data);
-ngx_int_t ngx_http_tfs_delete_duplicate_info(ngx_http_tfs_dedup_ctx_t *ctx,
-    ngx_pool_t *pool, ngx_log_t *log, ngx_chain_t *data);
+ngx_int_t ngx_http_tfs_dedup_get(ngx_http_tfs_dedup_ctx_t *ctx,
+    ngx_pool_t *pool, ngx_log_t *log);
+ngx_int_t ngx_http_tfs_dedup_set(ngx_http_tfs_dedup_ctx_t *ctx,
+    ngx_pool_t *pool, ngx_log_t *log);
+ngx_int_t ngx_http_tfs_dedup_remove(ngx_http_tfs_dedup_ctx_t *ctx,
+    ngx_pool_t *pool, ngx_log_t *log);
 
 ngx_int_t ngx_http_tfs_get_dedup_instance(ngx_http_tfs_dedup_ctx_t *ctx,
     ngx_http_tfs_tair_server_addr_info_t *server_addr_info,

--- a/src/ngx_http_tfs_errno.h
+++ b/src/ngx_http_tfs_errno.h
@@ -24,22 +24,22 @@
 #define NGX_HTTP_TFS_EXIT_CHECK_CRC_ERROR          -1010
 #define NGX_HTTP_TFS_EXIT_SERIALIZE_ERROR          -1011
 #define NGX_HTTP_TFS_EXIT_DESERIALIZE_ERROR        -1012
-//access permission error
+/* access permission error */
 #define NGX_HTTP_TFS_EXIT_ACCESS_PERMISSION_ERROR  -1013
-//system parameter error
+/* system parameter error */
 #define NGX_HTTP_TFS_EXIT_SYSTEM_PARAMETER_ERROR   -1014
 #define NGX_HTTP_TFS_EXIT_UNIQUE_META_NOT_EXIST    -1015
-//fuction parameter error
+/* fuction parameter error */
 #define NGX_HTTP_TFS_EXIT_PARAMETER_ERROR          -1016
-//mmap file failed
+/* mmap file failed */
 #define NGX_HTTP_TFS_EXIT_MMAP_FILE_ERROR          -1017
-//lru value not found by key
+/* lru value not found by key */
 #define NGX_HTTP_TFS_EXIT_LRU_VALUE_NOT_EXIST      -1018
-//lru value existed
+/* lru value existed */
 #define NGX_HTTP_TFS_EXIT_LRU_VALUE_EXIST          -1019
-//channel id invalid
+/* channel id invalid */
 #define NGX_HTTP_TFS_EXIT_CHANNEL_ID_INVALID       -1020
-//data packet timeout
+/* data packet timeout */
 #define NGX_HTTP_TFS_EXIT_DATA_PACKET_TIMEOUT      -1021
 
 #define NGX_HTTP_TFS_EXIT_FILE_OP_ERROR            -2000
@@ -59,151 +59,161 @@
 #define NGX_HTTP_TFS_EXIT_SENDMSG_ERROR            -3003
 #define NGX_HTTP_TFS_EXIT_RECVMSG_ERROR            -3004
 #define NGX_HTTP_TFS_EXIT_TIMEOUT_ERROR            -3005
-//waitid exist error
+/* waitid exist error */
 #define NGX_HTTP_TFS_EXIT_WAITID_EXIST_ERROR       -3006
-//waitid not found in waitid set
+/* waitid not found in waitid set */
 #define NGX_HTTP_TFS_EXIT_WAITID_NOT_FOUND_ERROR   -3007
-//socket nof found in socket map
+/* socket nof found in socket map */
 #define NGX_HTTP_TFS_EXIT_SOCKET_NOT_FOUND_ERROR   -3008
 
-#define NGX_HTTP_TFS_EXIT_TFS_ERROR     -5000
-#define NGX_HTTP_TFS_EXIT_NO_BLOCK     -5001
-#define NGX_HTTP_TFS_EXIT_NO_DATASERVER     -5002
-#define NGX_HTTP_TFS_EXIT_BLOCK_NOT_FOUND     -5003
+#define NGX_HTTP_TFS_EXIT_TFS_ERROR                -5000
+#define NGX_HTTP_TFS_EXIT_NO_BLOCK                 -5001
+#define NGX_HTTP_TFS_EXIT_NO_DATASERVER            -5002
+#define NGX_HTTP_TFS_EXIT_BLOCK_NOT_FOUND          -5003
 #define NGX_HTTP_TFS_EXIT_DATASERVER_NOT_FOUND     -5004
-// lease not found
-#define NGX_HTTP_TFS_EXIT_CANNOT_GET_LEASE     -5005
-#define NGX_HTTP_TFS_EXIT_COMMIT_ERROR     -5006
-#define NGX_HTTP_TFS_EXIT_LEASE_EXPIRED     -5007
-#define NGX_HTTP_TFS_EXIT_BINLOG_ERROR     -5008
-#define NGX_HTTP_TFS_EXIT_NO_REPLICATE     -5009
-#define NGX_HTTP_TFS_EXIT_BLOCK_BUSY     -5010
-//update block information version error
+/* lease not found */
+#define NGX_HTTP_TFS_EXIT_CANNOT_GET_LEASE         -5005
+#define NGX_HTTP_TFS_EXIT_COMMIT_ERROR             -5006
+#define NGX_HTTP_TFS_EXIT_LEASE_EXPIRED            -5007
+#define NGX_HTTP_TFS_EXIT_BINLOG_ERROR             -5008
+#define NGX_HTTP_TFS_EXIT_NO_REPLICATE             -5009
+#define NGX_HTTP_TFS_EXIT_BLOCK_BUSY               -5010
+/* update block information version error */
 #define NGX_HTTP_TFS_EXIT_UPDATE_BLOCK_INFO_VERSION_ERROR     -5011
-//access mode error
-#define NGX_HTTP_TFS_EXIT_ACCESS_MODE_ERROR     -5012
-//play log error
-#define NGX_HTTP_TFS_EXIT_PLAY_LOG_ERROR     -5013
-//current nameserver only read
-#define NGX_HTTP_TFS_EXIT_NAMESERVER_ONLY_READ     -5014
-//current block already exist
-#define NGX_HTTP_TFS_EXIT_BLOCK_ALREADY_EXIST     -5015
-//create block by block id failed
-#define NGX_HTTP_TFS_EXIT_CREATE_BLOCK_BY_ID_ERROR     -5016
-//server object not found in XXX
-#define NGX_HTTP_TFS_EIXT_SERVER_OBJECT_NOT_FOUND     -5017
-//update relation error
-#define NGX_HTTP_TFS_EXIT_UPDATE_RELATION_ERROR     -5018
-//nameserver in safe_mode_time, discard newblk packet
-#define NGX_HTTP_TFS_EXIT_DISCARD_NEWBLK_ERROR      -5019
+/* access mode error */
+#define NGX_HTTP_TFS_EXIT_ACCESS_MODE_ERROR                   -5012
+/* play log error */
+#define NGX_HTTP_TFS_EXIT_PLAY_LOG_ERROR                      -5013
+/* current nameserver only read */
+#define NGX_HTTP_TFS_EXIT_NAMESERVER_ONLY_READ                -5014
+/* current block already exist */
+#define NGX_HTTP_TFS_EXIT_BLOCK_ALREADY_EXIST                 -5015
+/* create block by block id failed */
+#define NGX_HTTP_TFS_EXIT_CREATE_BLOCK_BY_ID_ERROR            -5016
+/* server object not found in XXX */
+#define NGX_HTTP_TFS_EIXT_SERVER_OBJECT_NOT_FOUND             -5017
+/* update relation error */
+#define NGX_HTTP_TFS_EXIT_UPDATE_RELATION_ERROR               -5018
+/* nameserver in safe_mode_time, discard newblk packet */
+#define NGX_HTTP_TFS_EXIT_DISCARD_NEWBLK_ERROR                -5019
 
-// write offset error
-#define NGX_HTTP_TFS_EXIT_WRITE_OFFSET_ERROR     -8001
-// read offset error
-#define NGX_HTTP_TFS_EXIT_READ_OFFSET_ERROR     -8002
-// block id is zero, fatal error
-#define NGX_HTTP_TFS_EXIT_BLOCKID_ZERO_ERROR     -8003
-// block is used up, fatal error
-#define NGX_HTTP_TFS_EXIT_BLOCK_EXHAUST_ERROR     -8004
-// need extend too much physcial block when extend block
-#define NGX_HTTP_TFS_EXIT_PHYSICALBLOCK_NUM_ERROR     -8005
-// can't find logic block
-#define NGX_HTTP_TFS_EXIT_NO_LOGICBLOCK_ERROR     -8006
-// input point is null
-#define NGX_HTTP_TFS_EXIT_POINTER_NULL     -8007
-// cat find unused fileid in limited times
-#define NGX_HTTP_TFS_EXIT_CREATE_FILEID_ERROR     -8008
-// block id conflict
-#define NGX_HTTP_TFS_EXIT_BLOCKID_CONFLICT_ERROR     -8009
-// LogicBlock already Exists
-#define NGX_HTTP_TFS_EXIT_BLOCK_EXIST_ERROR     -8010
-// compact block error
-#define NGX_HTTP_TFS_EXIT_COMPACT_BLOCK_ERROR     -8011
-// read or write length is less than required
-#define NGX_HTTP_TFS_EXIT_DISK_OPER_INCOMPLETE     -8012
-// datafile is NULL  / crc / getdata error
-#define NGX_HTTP_TFS_EXIT_DATA_FILE_ERROR     -8013
-// too much data file
-#define NGX_HTTP_TFS_EXIT_DATAFILE_OVERLOAD     -8014
-// data file is expired
-#define NGX_HTTP_TFS_EXIT_DATAFILE_EXPIRE_ERROR     -8015
-// file flag or id error when read file
-#define NGX_HTTP_TFS_EXIT_FILE_INFO_ERROR     -8016
-// fileid is same in rename file
-#define NGX_HTTP_TFS_EXIT_RENAME_FILEID_SAME_ERROR     -8017
-// file status error(in unlinkfile)
-#define NGX_HTTP_TFS_EXIT_FILE_STATUS_ERROR     -8018
-// action is not defined(in unlinkfile)
-#define NGX_HTTP_TFS_EXIT_FILE_ACTION_ERROR     -8019
-// file system is not inited
-#define NGX_HTTP_TFS_EXIT_FS_NOTINIT_ERROR     -8020
-// file system's bit map conflict
-#define NGX_HTTP_TFS_EXIT_BITMAP_CONFLICT_ERROR     -8021
-// physical block is already exist in file system
-#define NGX_HTTP_TFS_EXIT_PHYSIC_UNEXPECT_FOUND_ERROR     -8022
-#define NGX_HTTP_TFS_EXIT_BLOCK_SETED_ERROR     -8023
-// index is loaded when create or load
-#define NGX_HTTP_TFS_EXIT_INDEX_ALREADY_LOADED_ERROR     -8024
-// meta not found in index
-#define NGX_HTTP_TFS_EXIT_META_NOT_FOUND_ERROR     -8025
-// meta found in index when insert
-#define NGX_HTTP_TFS_EXIT_META_UNEXPECT_FOUND_ERROR     -8026
-// require offset is out of index size
-#define NGX_HTTP_TFS_EXIT_META_OFFSET_ERROR     -8027
-// bucket size is conflict with before
-#define NGX_HTTP_TFS_EXIT_BUCKET_CONFIGURE_ERROR     -8028
-// index already exist when create index
-#define NGX_HTTP_TFS_EXIT_INDEX_UNEXPECT_EXIST_ERROR     -8029
- // index is corrupted, and index is created
-#define NGX_HTTP_TFS_EXIT_INDEX_CORRUPT_ERROR     -8030
-#define NGX_HTTP_TFS_EXIT_BLOCK_DS_VERSION_ERROR     -8031 // ds version error
-#define NGX_HTTP_TFS_EXIT_BLOCK_NS_VERSION_ERROR     -8332 // ns version error
-// offset is out of physical block size
-#define NGX_HTTP_TFS_EXIT_PHYSIC_BLOCK_OFFSET_ERROR     -8033
-// file size is little than fileinfo
-#define NGX_HTTP_TFS_EXIT_READ_FILE_SIZE_ERROR     -8034
-#define NGX_HTTP_TFS_EXIT_DS_CONNECT_ERROR     -8035 // connect to ds fail
-// too much block checker
-#define NGX_HTTP_TFS_EXIT_BLOCK_CHECKER_OVERLOAD     -8036
-// fallocate is not implement
-#define NGX_HTTP_TFS_EXIT_FALLOCATE_NOT_IMPLEMENT     -8037
-#define NGX_HTTP_TFS_EXIT_SYNC_FILE_ERROR     -8038//sync file failed
+/* write offset error */
+#define NGX_HTTP_TFS_EXIT_WRITE_OFFSET_ERROR                  -8001
+/* read offset error */
+#define NGX_HTTP_TFS_EXIT_READ_OFFSET_ERROR                   -8002
+/* block id is zero, fatal error */
+#define NGX_HTTP_TFS_EXIT_BLOCKID_ZERO_ERROR                  -8003
+/* block is used up, fatal error */
+#define NGX_HTTP_TFS_EXIT_BLOCK_EXHAUST_ERROR                 -8004
+/* need extend too much physcial block when extend block */
+#define NGX_HTTP_TFS_EXIT_PHYSICALBLOCK_NUM_ERROR             -8005
+/* can't find logic block */
+#define NGX_HTTP_TFS_EXIT_NO_LOGICBLOCK_ERROR                 -8006
+/* input point is null */
+#define NGX_HTTP_TFS_EXIT_POINTER_NULL                        -8007
+/* cat find unused fileid in limited times */
+#define NGX_HTTP_TFS_EXIT_CREATE_FILEID_ERROR                 -8008
+/* block id conflict */
+#define NGX_HTTP_TFS_EXIT_BLOCKID_CONFLICT_ERROR              -8009
+/* LogicBlock already Exists */
+#define NGX_HTTP_TFS_EXIT_BLOCK_EXIST_ERROR                   -8010
+/* compact block error */
+#define NGX_HTTP_TFS_EXIT_COMPACT_BLOCK_ERROR                 -8011
+/* read or write length is less than required */
+#define NGX_HTTP_TFS_EXIT_DISK_OPER_INCOMPLETE                -8012
+/* datafile is NULL  / crc / getdata error */
+#define NGX_HTTP_TFS_EXIT_DATA_FILE_ERROR                     -8013
+/* too much data file */
+#define NGX_HTTP_TFS_EXIT_DATAFILE_OVERLOAD                   -8014
+/* data file is expired */
+#define NGX_HTTP_TFS_EXIT_DATAFILE_EXPIRE_ERROR               -8015
+/* file flag or id error when read file */
+#define NGX_HTTP_TFS_EXIT_FILE_INFO_ERROR                     -8016
+/* fileid is same in rename file */
+#define NGX_HTTP_TFS_EXIT_RENAME_FILEID_SAME_ERROR            -8017
+/* file status error(in unlinkfile) */
+#define NGX_HTTP_TFS_EXIT_FILE_STATUS_ERROR                   -8018
+/* action is not defined(in unlinkfile) */
+#define NGX_HTTP_TFS_EXIT_FILE_ACTION_ERROR                   -8019
+/* file system is not inited */
+#define NGX_HTTP_TFS_EXIT_FS_NOTINIT_ERROR                    -8020
+/* file system's bit map conflict */
+#define NGX_HTTP_TFS_EXIT_BITMAP_CONFLICT_ERROR               -8021
+/* physical block is already exist in file system */
+#define NGX_HTTP_TFS_EXIT_PHYSIC_UNEXPECT_FOUND_ERROR         -8022
+#define NGX_HTTP_TFS_EXIT_BLOCK_SETED_ERROR                   -8023
+/* index is loaded when create or load */
+#define NGX_HTTP_TFS_EXIT_INDEX_ALREADY_LOADED_ERROR          -8024
+/* meta not found in index */
+#define NGX_HTTP_TFS_EXIT_META_NOT_FOUND_ERROR                -8025
+/* meta found in index when insert */
+#define NGX_HTTP_TFS_EXIT_META_UNEXPECT_FOUND_ERROR           -8026
+/* require offset is out of index size */
+#define NGX_HTTP_TFS_EXIT_META_OFFSET_ERROR                   -8027
+/* bucket size is conflict with before */
+#define NGX_HTTP_TFS_EXIT_BUCKET_CONFIGURE_ERROR              -8028
+/* index already exist when create index */
+#define NGX_HTTP_TFS_EXIT_INDEX_UNEXPECT_EXIST_ERROR          -8029
+/* index is corrupted, and index is created */
+#define NGX_HTTP_TFS_EXIT_INDEX_CORRUPT_ERROR                 -8030
+/* ds version error */
+#define NGX_HTTP_TFS_EXIT_BLOCK_DS_VERSION_ERROR              -8031
+/* ns version error */
+#define NGX_HTTP_TFS_EXIT_BLOCK_NS_VERSION_ERROR              -8332
+/* offset is out of physical block size */
+#define NGX_HTTP_TFS_EXIT_PHYSIC_BLOCK_OFFSET_ERROR           -8033
+/* file size is little than fileinfo */
+#define NGX_HTTP_TFS_EXIT_READ_FILE_SIZE_ERROR                -8034
+/* connect to ds fail */
+#define NGX_HTTP_TFS_EXIT_DS_CONNECT_ERROR                    -8035
+/* too much block checker */
+#define NGX_HTTP_TFS_EXIT_BLOCK_CHECKER_OVERLOAD              -8036
+/* fallocate is not implement */
+#define NGX_HTTP_TFS_EXIT_FALLOCATE_NOT_IMPLEMENT             -8037
+/* sync file failed */
+#define NGX_HTTP_TFS_EXIT_SYNC_FILE_ERROR                     -8038
 
-#define NGX_HTTP_TFS_EXIT_SESSION_EXIST_ERROR     -9001
-#define NGX_HTTP_TFS_EXIT_SESSIONID_INVALID_ERROR     -9002
-#define NGX_HTTP_TFS_EXIT_APP_NOTEXIST_ERROR     -9010
-#define NGX_HTTP_TFS_EXIT_APPID_PERMISSION_DENY     -9011
+#define NGX_HTTP_TFS_EXIT_SESSION_EXIST_ERROR                 -9001
+#define NGX_HTTP_TFS_EXIT_SESSIONID_INVALID_ERROR             -9002
+#define NGX_HTTP_TFS_EXIT_APP_NOTEXIST_ERROR                  -9010
+#define NGX_HTTP_TFS_EXIT_APPID_PERMISSION_DENY               -9011
 
-#define NGX_HTTP_TFS_EXIT_SYSTEM_ERROR     -10000
-#define NGX_HTTP_TFS_EXIT_REGISTER_OPLOG_SYNC_ERROR     -12000
-#define NGX_HTTP_TFS_EXIT_MAKEDIR_ERROR     -13000
+#define NGX_HTTP_TFS_EXIT_SYSTEM_ERROR                        -10000
+#define NGX_HTTP_TFS_EXIT_REGISTER_OPLOG_SYNC_ERROR           -12000
+#define NGX_HTTP_TFS_EXIT_MAKEDIR_ERROR                       -13000
 
-#define NGX_HTTP_TFS_EXIT_UNKNOWN_SQL_ERROR    -14000
-#define NGX_HTTP_TFS_EXIT_TARGET_EXIST_ERROR     -14001
-#define NGX_HTTP_TFS_EXIT_PARENT_EXIST_ERROR     -14002
-#define NGX_HTTP_TFS_EXIT_DELETE_DIR_WITH_FILE_ERROR     -14003
-#define NGX_HTTP_TFS_EXIT_VERSION_CONFLICT_ERROR     -14004
-#define NGX_HTTP_TFS_EXIT_NOT_CREATE_ERROR     -14005
-#define NGX_HTTP_TFS_EXIT_CLUSTER_ID_ERROR     -14006
-#define NGX_HTTP_TFS_EXIT_FRAG_META_OVERFLOW_ERROR     -14007
-#define NGX_HTTP_TFS_EXIT_UPDATE_FRAG_INFO_ERROR     -14008
-#define NGX_HTTP_TFS_EXIT_WRITE_EXIST_POS_ERROR     -14009
-#define NGX_HTTP_TFS_EXIT_INVALID_FILE_NAME     -14010
-#define NGX_HTTP_TFS_EXIT_MOVE_TO_SUB_DIR_ERROR     -14011
-#define NGX_HTTP_TFS_EXIT_OVER_MAX_SUB_DIRS_COUNT     -14012
-#define NGX_HTTP_TFS_EXIT_OVER_MAX_SUB_DIRS_DEEP     -14013
-#define NGX_HTTP_TFS_EXIT_OVER_MAX_SUB_FILES_COUNT     -14014
+#define NGX_HTTP_TFS_EXIT_UNKNOWN_SQL_ERROR                   -14000
+#define NGX_HTTP_TFS_EXIT_TARGET_EXIST_ERROR                  -14001
+#define NGX_HTTP_TFS_EXIT_PARENT_EXIST_ERROR                  -14002
+#define NGX_HTTP_TFS_EXIT_DELETE_DIR_WITH_FILE_ERROR          -14003
+#define NGX_HTTP_TFS_EXIT_VERSION_CONFLICT_ERROR              -14004
+#define NGX_HTTP_TFS_EXIT_NOT_CREATE_ERROR                    -14005
+#define NGX_HTTP_TFS_EXIT_CLUSTER_ID_ERROR                    -14006
+#define NGX_HTTP_TFS_EXIT_FRAG_META_OVERFLOW_ERROR            -14007
+#define NGX_HTTP_TFS_EXIT_UPDATE_FRAG_INFO_ERROR              -14008
+#define NGX_HTTP_TFS_EXIT_WRITE_EXIST_POS_ERROR               -14009
+#define NGX_HTTP_TFS_EXIT_INVALID_FILE_NAME                   -14010
+#define NGX_HTTP_TFS_EXIT_MOVE_TO_SUB_DIR_ERROR               -14011
+#define NGX_HTTP_TFS_EXIT_OVER_MAX_SUB_DIRS_COUNT             -14012
+#define NGX_HTTP_TFS_EXIT_OVER_MAX_SUB_DIRS_DEEP              -14013
+#define NGX_HTTP_TFS_EXIT_OVER_MAX_SUB_FILES_COUNT            -14014
 
-#define NGX_HTTP_TFS_EXIT_REGISTER_ERROR     -15000// server register fail
-// server register fail, server is existed
-#define NGX_HTTP_TFS_EXIT_REGISTER_EXIST_ERROR     -15001
-// renew lease fail, server is not existed
-#define NGX_HTTP_TFS_EXIT_REGISTER_NOT_EXIST_ERROR     -15002
-#define NGX_HTTP_TFS_EXIT_TABLE_VERSION_ERROR     -15003//table version error
-#define NGX_HTTP_TFS_EXIT_BUCKET_ID_INVLAID    -15004//bucket id invalid
-#define NGX_HTTP_TFS_EXIT_BUCKET_NOT_EXIST    -15005//bucket not exist
-#define NGX_HTTP_TFS_EXIT_NEW_TABLE_NOT_EXIST    -15005//new table not exist
-#define NGX_HTTP_TFS_EXIT_NEW_TABLE_INVALID     -15005//new table invalid
+/* server register fail */
+#define NGX_HTTP_TFS_EXIT_REGISTER_ERROR                      -15000
+/* server register fail, server is existed */
+#define NGX_HTTP_TFS_EXIT_REGISTER_EXIST_ERROR                -15001
+/* renew lease fail, server is not existed */
+#define NGX_HTTP_TFS_EXIT_REGISTER_NOT_EXIST_ERROR            -15002
+/* table version error */
+#define NGX_HTTP_TFS_EXIT_TABLE_VERSION_ERROR                 -15003
+/* bucket id invalid */
+#define NGX_HTTP_TFS_EXIT_BUCKET_ID_INVLAID                   -15004
+/* bucket not exist */
+#define NGX_HTTP_TFS_EXIT_BUCKET_NOT_EXIST                    -15005
+/* new table not exist */
+#define NGX_HTTP_TFS_EXIT_NEW_TABLE_NOT_EXIST                 -15005
+/* new table invalid */
+#define NGX_HTTP_TFS_EXIT_NEW_TABLE_INVALID                   -15005
 
 
 #endif  /* _NGX_HTTP_TFS_ERRNO_H_INCLUDED_ */

--- a/src/ngx_http_tfs_json.c
+++ b/src/ngx_http_tfs_json.c
@@ -11,8 +11,8 @@
 ngx_http_tfs_json_gen_t *
 ngx_http_tfs_json_init(ngx_log_t *log, ngx_pool_t *pool)
 {
-    yajl_gen                          g;
-    ngx_http_tfs_json_gen_t          *tj_gen;
+    yajl_gen                  g;
+    ngx_http_tfs_json_gen_t  *tj_gen;
 
     g = yajl_gen_alloc(NULL);
     if (g == NULL) {
@@ -48,15 +48,15 @@ ngx_chain_t *
 ngx_http_tfs_json_custom_file_info(ngx_http_tfs_json_gen_t *tj_gen,
     ngx_http_tfs_custom_meta_info_t *meta_info, uint8_t file_type)
 {
-    size_t                           size;
-    u_char                           time_buf[NGX_HTTP_TFS_GMT_TIME_SIZE];
-    yajl_gen                         g;
-    uint32_t                         count;
-    ngx_buf_t                       *b;
-    ngx_int_t                        is_file;
-    ngx_uint_t                       i;
-    ngx_chain_t                     *cl;
-    ngx_http_tfs_custom_file_t      *file;
+    size_t                       size;
+    u_char                       time_buf[NGX_HTTP_TFS_GMT_TIME_SIZE];
+    yajl_gen                     g;
+    uint32_t                     count;
+    ngx_buf_t                   *b;
+    ngx_int_t                    is_file;
+    ngx_uint_t                   i;
+    ngx_chain_t                 *cl;
+    ngx_http_tfs_custom_file_t  *file;
 
     g = tj_gen->gen;
     size = 0;
@@ -139,10 +139,10 @@ ngx_chain_t *
 ngx_http_tfs_json_file_name(ngx_http_tfs_json_gen_t *tj_gen,
     ngx_str_t *file_name)
 {
-    size_t                      size;
-    yajl_gen                    g;
-    ngx_buf_t                  *b;
-    ngx_chain_t                *cl;
+    size_t        size;
+    yajl_gen      g;
+    ngx_buf_t    *b;
+    ngx_chain_t  *cl;
 
     g = tj_gen->gen;
     size = 0;
@@ -178,11 +178,11 @@ ngx_http_tfs_json_raw_file_info(ngx_http_tfs_json_gen_t *tj_gen,
     u_char* file_name, uint32_t block_id,
     ngx_http_tfs_raw_file_info_t *file_info)
 {
-    size_t                      size;
-    u_char                      time_buf[NGX_HTTP_TFS_GMT_TIME_SIZE];
-    yajl_gen                    g;
-    ngx_buf_t                  *b;
-    ngx_chain_t                *cl;
+    size_t        size;
+    u_char        time_buf[NGX_HTTP_TFS_GMT_TIME_SIZE];
+    yajl_gen      g;
+    ngx_buf_t    *b;
+    ngx_chain_t  *cl;
 
     g = tj_gen->gen;
     size = 0;
@@ -253,10 +253,10 @@ ngx_chain_t *
 ngx_http_tfs_json_appid(ngx_http_tfs_json_gen_t *tj_gen,
     uint64_t app_id)
 {
-    size_t                      size;
-    yajl_gen                    g;
-    ngx_buf_t                  *b;
-    ngx_chain_t                *cl;
+    size_t        size;
+    yajl_gen      g;
+    ngx_buf_t    *b;
+    ngx_chain_t  *cl;
 
     g = tj_gen->gen;
     size = 0;
@@ -296,12 +296,12 @@ ngx_chain_t *
 ngx_http_tfs_json_file_hole_info(ngx_http_tfs_json_gen_t *tj_gen,
     ngx_array_t *file_holes)
 {
-    size_t                           size;
-    yajl_gen                         g;
-    ngx_buf_t                       *b;
-    ngx_uint_t                       i;
-    ngx_chain_t                     *cl;
-    ngx_http_tfs_file_hole_info_t   *file_hole_info;
+    size_t                          size;
+    yajl_gen                        g;
+    ngx_buf_t                      *b;
+    ngx_uint_t                      i;
+    ngx_chain_t                    *cl;
+    ngx_http_tfs_file_hole_info_t  *file_hole_info;
 
     g = tj_gen->gen;
     size = 0;

--- a/src/ngx_http_tfs_local_block_cache.c
+++ b/src/ngx_http_tfs_local_block_cache.c
@@ -8,15 +8,16 @@
 
 
 static void ngx_http_tfs_local_block_cache_rbtree_insert_value(
-    ngx_rbtree_node_t *temp,
-    ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
+    ngx_rbtree_node_t *temp, ngx_rbtree_node_t *node,
+    ngx_rbtree_node_t *sentinel);
+
 
 ngx_int_t
 ngx_http_tfs_local_block_cache_init_zone(ngx_shm_zone_t *shm_zone, void *data)
 {
-    size_t                                   len;
-    ngx_http_tfs_local_block_cache_ctx_t    *ctx;
-    ngx_http_tfs_local_block_cache_ctx_t    *octx = data;
+    size_t                                 len;
+    ngx_http_tfs_local_block_cache_ctx_t  *ctx;
+    ngx_http_tfs_local_block_cache_ctx_t  *octx = data;
 
     ctx = shm_zone->data;
 
@@ -81,7 +82,8 @@ ngx_http_tfs_local_block_cache_rbtree_insert_value(ngx_rbtree_node_t *temp,
         } else if (node->key > temp->key) {
             p = &temp->right;
 
-        } else { /* node->key == temp->key */
+        } else {
+            /* node->key == temp->key */
             tbn = (ngx_http_tfs_block_cache_node_t *) &node->color;
             tbnt = (ngx_http_tfs_block_cache_node_t *) &temp->color;
 
@@ -106,8 +108,7 @@ ngx_http_tfs_local_block_cache_rbtree_insert_value(ngx_rbtree_node_t *temp,
 
 ngx_int_t
 ngx_http_tfs_local_block_cache_lookup(ngx_http_tfs_local_block_cache_ctx_t *ctx,
-    ngx_pool_t *pool, ngx_log_t *log,
-    ngx_http_tfs_block_cache_key_t* key,
+    ngx_pool_t *pool, ngx_log_t *log, ngx_http_tfs_block_cache_key_t* key,
     ngx_http_tfs_block_cache_value_t *value)
 {
     double                            hit_ratio;
@@ -186,8 +187,7 @@ ngx_http_tfs_local_block_cache_lookup(ngx_http_tfs_local_block_cache_ctx_t *ctx,
 
 ngx_int_t
 ngx_http_tfs_local_block_cache_insert(ngx_http_tfs_local_block_cache_ctx_t *ctx,
-    ngx_log_t *log,
-    ngx_http_tfs_block_cache_key_t *key,
+    ngx_log_t *log, ngx_http_tfs_block_cache_key_t *key,
     ngx_http_tfs_block_cache_value_t *value)
 {
     size_t                            n;
@@ -298,10 +298,10 @@ void
 ngx_http_tfs_local_block_cache_discard(
     ngx_http_tfs_local_block_cache_ctx_t *ctx)
 {
-    ngx_uint_t                          i;
-    ngx_queue_t                        *q, *h, *p;
-    ngx_rbtree_node_t                  *node;
-    ngx_http_tfs_block_cache_node_t    *bcn;
+    ngx_uint_t                        i;
+    ngx_queue_t                      *q, *h, *p;
+    ngx_rbtree_node_t                *node;
+    ngx_http_tfs_block_cache_node_t  *bcn;
 
     h = &ctx->sh->queue;
     if (ngx_queue_empty(h)) {
@@ -339,15 +339,15 @@ ngx_http_tfs_local_block_cache_batch_lookup(
     ngx_http_tfs_local_block_cache_ctx_t *ctx,
     ngx_pool_t *pool, ngx_log_t *log, ngx_array_t *keys, ngx_array_t *kvs)
 {
-    double                                hit_ratio; 
-    ngx_int_t                             rc;
-    ngx_uint_t                            i, hash, hit_count;
-    ngx_slab_pool_t                      *shpool;
-    ngx_rbtree_node_t                    *node, *sentinel;
-    ngx_http_tfs_block_cache_kv_t        *kv;
-    ngx_http_tfs_block_cache_key_t       *key;
-    ngx_http_tfs_block_cache_node_t      *bcn;
-    ngx_http_tfs_block_cache_value_t     *value;
+    double                           hit_ratio;
+    ngx_int_t                        rc;
+    ngx_uint_t                       i, hash, hit_count;
+    ngx_slab_pool_t                  *shpool;
+    ngx_rbtree_node_t                *node, *sentinel;
+    ngx_http_tfs_block_cache_kv_t    *kv;
+    ngx_http_tfs_block_cache_key_t   *key;
+    ngx_http_tfs_block_cache_node_t  *bcn;
+    ngx_http_tfs_block_cache_value_t *value;
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
                    "batch lookup local block cache, block count: %ui",

--- a/src/ngx_http_tfs_meta_server_message.c
+++ b/src/ngx_http_tfs_meta_server_message.c
@@ -27,8 +27,8 @@ static ngx_int_t ngx_http_tfs_parse_ls_message(ngx_http_tfs_t *t);
 ngx_http_tfs_inet_t *
 ngx_http_tfs_select_meta_server(ngx_http_tfs_t *t)
 {
-    uint32_t                        hash, index;
-    ngx_http_tfs_meta_hh_t          h;
+    uint32_t                hash, index;
+    ngx_http_tfs_meta_hh_t  h;
 
     h.app_id = ngx_hton64(t->r_ctx.app_id);
     h.user_id = ngx_hton64(t->r_ctx.user_id);
@@ -45,8 +45,8 @@ ngx_http_tfs_select_meta_server(ngx_http_tfs_t *t)
 ngx_chain_t *
 ngx_http_tfs_meta_server_create_message(ngx_http_tfs_t *t)
 {
-    uint16_t             msg_type;
-    ngx_chain_t         *cl;
+    uint16_t      msg_type;
+    ngx_chain_t  *cl;
 
     cl = NULL;
     msg_type = t->r_ctx.action.code;
@@ -63,18 +63,22 @@ ngx_http_tfs_meta_server_create_message(ngx_http_tfs_t *t)
                       &t->last_file_path);
         cl = ngx_http_tfs_create_action_message(t, &t->last_file_path, NULL);
         break;
+
     case NGX_HTTP_TFS_ACTION_MOVE_DIR:
     case NGX_HTTP_TFS_ACTION_MOVE_FILE:
         cl = ngx_http_tfs_create_action_message(t, &t->r_ctx.file_path_s,
                                                 &t->last_file_path);
         break;
+
     case NGX_HTTP_TFS_ACTION_REMOVE_DIR:
         cl = ngx_http_tfs_create_action_message(t, &t->r_ctx.file_path_s, NULL);
         break;
+
     case NGX_HTTP_TFS_ACTION_READ_FILE:
         cl = ngx_http_tfs_create_read_meta_message(t, t->file.file_offset,
                                                    t->file.left_length);
         break;
+
     case NGX_HTTP_TFS_ACTION_WRITE_FILE:
         switch (t->state) {
         case NGX_HTTP_TFS_STATE_WRITE_CLUSTER_ID_MS:
@@ -85,6 +89,7 @@ ngx_http_tfs_meta_server_create_message(ngx_http_tfs_t *t)
             break;
         }
         break;
+
     case NGX_HTTP_TFS_ACTION_REMOVE_FILE:
         switch (t->state) {
         case NGX_HTTP_TFS_STATE_REMOVE_GET_FRAG_INFO:
@@ -97,6 +102,7 @@ ngx_http_tfs_meta_server_create_message(ngx_http_tfs_t *t)
             break;
         }
         break;
+
     case NGX_HTTP_TFS_ACTION_LS_DIR:
     case NGX_HTTP_TFS_ACTION_LS_FILE:
         t->json_output = ngx_http_tfs_json_init(t->log, t->pool);
@@ -114,7 +120,7 @@ ngx_http_tfs_meta_server_create_message(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_meta_server_parse_message(ngx_http_tfs_t *t)
 {
-    uint16_t                               action;
+    uint16_t  action;
 
     action = t->r_ctx.action.code;
 
@@ -506,8 +512,9 @@ ngx_http_tfs_parse_read_meta_message(ngx_http_tfs_t *t)
     uint16_t                             type;
     uint32_t                             count;
     uint64_t                             end_offset;
-    ngx_int_t                            i, rc;
+    ngx_int_t                            rc;
     ngx_str_t                            action;
+    ngx_uint_t                           i;
     ngx_http_tfs_header_t               *header;
     ngx_http_tfs_segment_data_t         *first_segment, *last_segment,
                                         *segment_data;
@@ -682,10 +689,10 @@ ngx_http_tfs_parse_read_meta_message(ngx_http_tfs_t *t)
 static ngx_int_t
 ngx_http_tfs_parse_action_message(ngx_http_tfs_t *t)
 {
-    uint16_t                                  type;
-    ngx_str_t                                 action;
-    ngx_http_tfs_header_t                    *header;
-    ngx_http_tfs_peer_connection_t           *tp;
+    uint16_t                         type;
+    ngx_str_t                        action;
+    ngx_http_tfs_header_t           *header;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     tp = t->tfs_peer;
     header = (ngx_http_tfs_header_t *) t->header;

--- a/src/ngx_http_tfs_module.c
+++ b/src/ngx_http_tfs_module.c
@@ -207,11 +207,11 @@ ngx_module_t  ngx_http_tfs_module = {
 static ngx_int_t
 ngx_http_tfs_handler(ngx_http_request_t *r)
 {
-    ngx_int_t                       rc;
-    ngx_http_tfs_t                 *t;
-    ngx_http_tfs_loc_conf_t        *tlcf;
-    ngx_http_tfs_srv_conf_t        *tscf;
-    ngx_http_tfs_main_conf_t       *tmcf;
+    ngx_int_t                  rc;
+    ngx_http_tfs_t            *t;
+    ngx_http_tfs_loc_conf_t   *tlcf;
+    ngx_http_tfs_srv_conf_t   *tscf;
+    ngx_http_tfs_main_conf_t  *tmcf;
 
     tlcf = ngx_http_get_module_loc_conf(r, ngx_http_tfs_module);
     tscf = ngx_http_get_module_srv_conf(r, ngx_http_tfs_module);
@@ -300,9 +300,9 @@ ngx_http_tfs_handler(ngx_http_request_t *r)
 ngx_http_tfs_upstream_t *
 ngx_http_tfs_upstream_add(ngx_conf_t *cf, ngx_url_t *u, ngx_uint_t flags)
 {
-    ngx_uint_t                      i;
-    ngx_http_tfs_upstream_t        *tu, **tup;
-    ngx_http_tfs_main_conf_t       *tmcf;
+    ngx_uint_t                 i;
+    ngx_http_tfs_upstream_t   *tu, **tup;
+    ngx_http_tfs_main_conf_t  *tmcf;
 
     if (!(flags & NGX_HTTP_TFS_UPSTREAM_CREATE)) {
 
@@ -369,11 +369,11 @@ ngx_http_tfs_upstream_add(ngx_conf_t *cf, ngx_url_t *u, ngx_uint_t flags)
 static char *
 ngx_http_tfs_upstream(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-    char                           *rv;
-    ngx_url_t                       u;
-    ngx_str_t                      *value;
-    ngx_conf_t                      pcf;
-    ngx_http_tfs_upstream_t        *tu;
+    char                     *rv;
+    ngx_url_t                 u;
+    ngx_str_t                *value;
+    ngx_conf_t                pcf;
+    ngx_http_tfs_upstream_t  *tu;
 
     ngx_memzero(&u, sizeof(ngx_url_t));
 
@@ -437,9 +437,9 @@ ngx_http_tfs_upstream(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 static char *
 ngx_http_tfs_upstream_parse(ngx_conf_t *cf, ngx_command_t *dummy, void *conf)
 {
-    ngx_url_t                       u;
-    ngx_str_t                      *value, *server_addr;
-    ngx_http_tfs_upstream_t        *tu;
+    ngx_url_t                 u;
+    ngx_str_t                *value, *server_addr;
+    ngx_http_tfs_upstream_t  *tu;
 
     tu = cf->ctx;
 
@@ -523,10 +523,10 @@ ngx_http_tfs_keepalive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
     ngx_http_tfs_main_conf_t  *tmcf = conf;
 
-    ngx_int_t                       max_cached, bucket_count;
-    ngx_str_t                      *value, s;
-    ngx_uint_t                      i;
-    ngx_http_connection_pool_t     *p;
+    ngx_int_t                    max_cached, bucket_count;
+    ngx_str_t                   *value, s;
+    ngx_uint_t                   i;
+    ngx_http_connection_pool_t  *p;
 
     value = cf->args->elts;
     max_cached = 0;
@@ -583,9 +583,9 @@ invalid:
 static char *
 ngx_http_tfs_rcs_heartbeat(ngx_conf_t *cf, ngx_http_tfs_upstream_t *tu)
 {
-    ngx_msec_t               interval;
-    ngx_str_t               *value, s;
-    ngx_uint_t               i;
+    ngx_str_t  *value, s;
+    ngx_msec_t  interval;
+    ngx_uint_t  i;
 
     value = cf->args->elts;
 
@@ -645,8 +645,8 @@ rcs_timers_error:
 static char *
 ngx_http_tfs_rcs_interface(ngx_conf_t *cf, ngx_http_tfs_upstream_t *tu)
 {
-    ngx_int_t                       rc;
-    ngx_str_t                      *value;
+    ngx_int_t   rc;
+    ngx_str_t  *value;
 
     if (cf->args->nelts != 2) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
@@ -672,8 +672,9 @@ ngx_http_tfs_rcs_interface(ngx_conf_t *cf, ngx_http_tfs_upstream_t *tu)
 static char *
 ngx_http_tfs_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-    ngx_http_tfs_srv_conf_t                *tscf = conf;
-    ngx_str_t                              *value;
+    ngx_http_tfs_srv_conf_t  *tscf = conf;
+
+    ngx_str_t  *value;
 
     if (tscf->log != NULL) {
         return "is duplicate";
@@ -718,7 +719,7 @@ ngx_http_tfs_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 static void *
 ngx_http_tfs_create_main_conf(ngx_conf_t *cf)
 {
-    ngx_http_tfs_main_conf_t           *conf;
+    ngx_http_tfs_main_conf_t  *conf;
 
     conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_tfs_main_conf_t));
     if (conf == NULL) {
@@ -780,7 +781,7 @@ ngx_http_tfs_init_main_conf(ngx_conf_t *cf, void *conf)
     }
 
     if (tmcf->body_buffer_size == NGX_CONF_UNSET_SIZE) {
-        tmcf->body_buffer_size = (size_t) ngx_pagesize * 2;
+        tmcf->body_buffer_size = NGX_HTTP_TFS_DEFAULT_BODY_BUFFER_SIZE;
     }
 
     return NGX_CONF_OK;
@@ -811,12 +812,12 @@ static char *ngx_http_tfs_merge_loc_conf(ngx_conf_t *cf,
 static char *
 ngx_http_tfs_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-    ngx_int_t                       add;
-    ngx_str_t                      *value, s;
-    ngx_url_t                       u;
-    ngx_http_tfs_main_conf_t       *tmcf;
-    ngx_http_tfs_loc_conf_t        *tlcf;
-    ngx_http_core_loc_conf_t       *clcf;
+    ngx_int_t                  add;
+    ngx_str_t                 *value, s;
+    ngx_url_t                  u;
+    ngx_http_tfs_loc_conf_t   *tlcf;
+    ngx_http_tfs_main_conf_t  *tmcf;
+    ngx_http_core_loc_conf_t  *clcf;
 
     value = cf->args->elts;
 
@@ -923,11 +924,11 @@ ngx_http_tfs_lowat_check(ngx_conf_t *cf, void *post, void *data)
 static char *
 ngx_http_tfs_rcs_zone(ngx_conf_t *cf, ngx_http_tfs_upstream_t *tu)
 {
-    ssize_t                          size;
-    ngx_str_t                       *value, s, name;
-    ngx_uint_t                       i;
-    ngx_shm_zone_t                  *shm_zone;
-    ngx_http_tfs_rc_ctx_t           *ctx;
+    ssize_t                 size;
+    ngx_str_t              *value, s, name;
+    ngx_uint_t              i;
+    ngx_shm_zone_t         *shm_zone;
+    ngx_http_tfs_rc_ctx_t  *ctx;
 
     value = cf->args->elts;
     size = 0;
@@ -1012,12 +1013,12 @@ ngx_http_tfs_rcs_zone(ngx_conf_t *cf, ngx_http_tfs_upstream_t *tu)
 static char *
 ngx_http_tfs_block_cache_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-    size_t                                  size;
-    ngx_str_t                              *value, s, name;
-    ngx_uint_t                              i;
-    ngx_shm_zone_t                         *shm_zone;
-    ngx_http_tfs_main_conf_t               *tmcf = conf;
-    ngx_http_tfs_local_block_cache_ctx_t   *ctx;
+    size_t                                 size;
+    ngx_str_t                             *value, s, name;
+    ngx_uint_t                             i;
+    ngx_shm_zone_t                        *shm_zone;
+    ngx_http_tfs_main_conf_t              *tmcf = conf;
+    ngx_http_tfs_local_block_cache_ctx_t  *ctx;
 
     value = cf->args->elts;
     size = 0;
@@ -1073,9 +1074,9 @@ ngx_http_tfs_block_cache_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 static void
 ngx_http_tfs_read_body_handler(ngx_http_request_t *r)
 {
-    ngx_int_t             rc;
-    ngx_http_tfs_t       *t;
-    ngx_connection_t     *c;
+    ngx_int_t          rc;
+    ngx_http_tfs_t    *t;
+    ngx_connection_t  *c;
 
     c = r->connection;
     t = ngx_http_get_module_ctx(r, ngx_http_tfs_module);
@@ -1141,10 +1142,10 @@ ngx_http_tfs_read_body_handler(ngx_http_request_t *r)
 static ngx_int_t
 ngx_http_tfs_module_init(ngx_cycle_t *cycle)
 {
-    ngx_uint_t                      i;
-    ngx_http_tfs_upstream_t       **tup;
-    ngx_http_tfs_main_conf_t       *tmcf;
-    ngx_http_tfs_timers_data_t     *data;
+    ngx_uint_t                   i;
+    ngx_http_tfs_upstream_t    **tup;
+    ngx_http_tfs_main_conf_t    *tmcf;
+    ngx_http_tfs_timers_data_t  *data;
 
     tmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_tfs_module);
     if (tmcf == NULL) {
@@ -1184,9 +1185,9 @@ ngx_http_tfs_module_init(ngx_cycle_t *cycle)
 static ngx_int_t
 ngx_http_tfs_check_init_worker(ngx_cycle_t *cycle)
 {
-    ngx_uint_t                      i;
-    ngx_http_tfs_upstream_t       **tup;
-    ngx_http_tfs_main_conf_t       *tmcf;
+    ngx_uint_t                 i;
+    ngx_http_tfs_upstream_t  **tup;
+    ngx_http_tfs_main_conf_t  *tmcf;
 
     /* rc keepalive */
     tmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_tfs_module);
@@ -1218,9 +1219,9 @@ ngx_http_tfs_check_init_worker(ngx_cycle_t *cycle)
 static void
 ngx_http_tfs_check_exit_worker(ngx_cycle_t *cycle)
 {
-    ngx_int_t                           i;
-    ngx_http_tfs_main_conf_t           *tmcf;
-    ngx_http_tfs_tair_instance_t       *dup_instance;
+    ngx_int_t                      i;
+    ngx_http_tfs_main_conf_t      *tmcf;
+    ngx_http_tfs_tair_instance_t  *dup_instance;
 
     tmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_tfs_module);
     if (tmcf == NULL) {

--- a/src/ngx_http_tfs_name_server_message.c
+++ b/src/ngx_http_tfs_name_server_message.c
@@ -163,7 +163,8 @@ ngx_http_tfs_select_name_server(ngx_http_tfs_t *t,
                 /* no master */
                 if (j == cluster_group_info[i].info_count) {
                     /* sth wrong in TFS cluster configure,
-                     * select the first cluster */
+                     * select the first cluster
+                     */
                     (*addr) = group_info[0].ns_vip;
                     (*addr_text) = group_info[0].ns_vip_text;
                     t->state = NGX_HTTP_TFS_STATE_REMOVE_GET_BLK_INFO;
@@ -208,7 +209,8 @@ ngx_http_tfs_select_name_server(ngx_http_tfs_t *t,
 find_logical_cluster_index:
 
         /* find out which logical cluster this addr belongs to
-           so that we can use the right de-dup addr */
+         * so that we can use the right de-dup addr
+         */
         t->logical_cluster_index = 0;
         for ( ;
               t->logical_cluster_index < rc_info->logical_cluster_count;
@@ -243,8 +245,8 @@ find_logical_cluster_index:
 ngx_chain_t *
 ngx_http_tfs_name_server_create_message(ngx_http_tfs_t *t)
 {
-    uint16_t             action;
-    ngx_chain_t         *cl;
+    uint16_t      action;
+    ngx_chain_t  *cl;
 
     cl = NULL;
     t->file.open_mode = 0;
@@ -338,8 +340,8 @@ ngx_http_tfs_name_server_create_message(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_name_server_parse_message(ngx_http_tfs_t *t)
 {
-    uint16_t                               action;
-    ngx_int_t                              rc;
+    uint16_t   action;
+    ngx_int_t  rc;
 
     action = t->r_ctx.action.code;
     rc = NGX_ERROR;
@@ -361,6 +363,7 @@ ngx_http_tfs_name_server_parse_message(ngx_http_tfs_t *t)
                                  &t->file.segment_data[t->file.segment_index]);
         }
         return rc;
+
     case NGX_HTTP_TFS_ACTION_WRITE_FILE:
         switch(t->state) {
         case NGX_HTTP_TFS_STATE_WRITE_CLUSTER_ID_NS:
@@ -380,6 +383,7 @@ ngx_http_tfs_name_server_parse_message(ngx_http_tfs_t *t)
             }
         }
         return rc;
+
     case NGX_HTTP_TFS_ACTION_REMOVE_FILE:
         switch(t->state) {
         case NGX_HTTP_TFS_STATE_REMOVE_GET_GROUP_COUNT:
@@ -408,10 +412,10 @@ static ngx_chain_t *
 ngx_http_tfs_create_block_info_message(ngx_http_tfs_t *t,
     ngx_http_tfs_segment_data_t *segment_data)
 {
-    size_t                                        size;
-    ngx_buf_t                                    *b;
-    ngx_chain_t                                  *cl;
-    ngx_http_tfs_ns_block_info_request_t         *req;
+    size_t                                size;
+    ngx_buf_t                             *b;
+    ngx_chain_t                           *cl;
+    ngx_http_tfs_ns_block_info_request_t  *req;
 
     size = sizeof(ngx_http_tfs_ns_block_info_request_t);
 
@@ -453,15 +457,15 @@ ngx_http_tfs_create_batch_block_info_message(ngx_http_tfs_t *t)
 {
     size_t                                       size;
     uint32_t                                     block_count, real_block_count;
-    ngx_int_t                                    i, j;
+    ngx_uint_t                                   i, j;
     ngx_buf_t                                   *b;
     ngx_chain_t                                 *cl;
     ngx_http_tfs_segment_data_t                 *segment_data;
     ngx_http_tfs_ns_batch_block_info_request_t  *req;
 
     block_count = t->file.segment_count - t->file.segment_index;
-    if (block_count > NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT) {
-        block_count = NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT;
+    if (block_count > NGX_HTTP_TFS_MAX_BATCH_COUNT) {
+        block_count = NGX_HTTP_TFS_MAX_BATCH_COUNT;
     }
 
     real_block_count = block_count;
@@ -523,10 +527,10 @@ ngx_http_tfs_create_batch_block_info_message(ngx_http_tfs_t *t)
 static ngx_chain_t *
 ngx_http_tfs_create_ctl_message(ngx_http_tfs_t *t, uint8_t cmd)
 {
-    size_t                                        size;
-    ngx_buf_t                                    *b;
-    ngx_chain_t                                  *cl;
-    ngx_http_tfs_ns_ctl_request_t                *req;
+    size_t                          size;
+    ngx_buf_t                      *b;
+    ngx_chain_t                    *cl;
+    ngx_http_tfs_ns_ctl_request_t  *req;
 
     size = sizeof(ngx_http_tfs_ns_ctl_request_t);
 
@@ -566,17 +570,17 @@ ngx_int_t
 ngx_http_tfs_parse_block_info_message(ngx_http_tfs_t *t,
     ngx_http_tfs_segment_data_t *segment_data)
 {
-    u_char                                   *p;
-    uint16_t                                  type;
-    uint32_t                                  ds_count;
-    ngx_str_t                                 err_msg;
-    ngx_uint_t                                i;
-    ngx_http_tfs_header_t                    *header;
-    ngx_http_tfs_block_info_t                *block_info;
-    ngx_http_tfs_block_cache_key_t            key;
-    ngx_http_tfs_block_cache_value_t          value;
-    ngx_http_tfs_peer_connection_t           *tp;
-    ngx_http_tfs_ns_block_info_response_t    *resp;
+    u_char                                 *p;
+    uint16_t                                type;
+    uint32_t                                ds_count;
+    ngx_str_t                               err_msg;
+    ngx_uint_t                              i;
+    ngx_http_tfs_header_t                  *header;
+    ngx_http_tfs_block_info_t              *block_info;
+    ngx_http_tfs_block_cache_key_t          key;
+    ngx_http_tfs_block_cache_value_t        value;
+    ngx_http_tfs_peer_connection_t         *tp;
+    ngx_http_tfs_ns_block_info_response_t  *resp;
 
     header = (ngx_http_tfs_header_t *) t->header;
     tp = t->tfs_peer;
@@ -694,8 +698,8 @@ ngx_http_tfs_parse_batch_block_info_message(ngx_http_tfs_t *t,
          + sizeof(ngx_http_tfs_ns_batch_block_info_response_t);
 
     block_count = t->file.segment_count - t->file.segment_index;
-    if (block_count > NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT) {
-        block_count = NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT;
+    if (block_count > NGX_HTTP_TFS_MAX_BATCH_COUNT) {
+        block_count = NGX_HTTP_TFS_MAX_BATCH_COUNT;
     }
     real_block_count = resp->block_count;
 
@@ -802,7 +806,8 @@ ngx_http_tfs_parse_batch_block_info_message(ngx_http_tfs_t *t,
                 {
                     continue;
                 }
-                //TODO: check this
+
+                /* TODO: check this */
                 segment_data[i].block_info = segment_data[j].block_info;
                 segment_data[i].block_info_src = NGX_HTTP_TFS_FROM_NS;
                 segment_data[i].ds_retry = 0;
@@ -822,10 +827,10 @@ ngx_http_tfs_parse_batch_block_info_message(ngx_http_tfs_t *t,
 static ngx_int_t
 ngx_http_tfs_parse_ctl_message(ngx_http_tfs_t *t, uint8_t cmd)
 {
-    uint32_t                                      code;
-    ngx_int_t                                     cluster_id;
-    ngx_http_tfs_status_msg_t                    *res;
-    ngx_http_tfs_peer_connection_t               *tp;
+    uint32_t                         code;
+    ngx_int_t                        cluster_id;
+    ngx_http_tfs_status_msg_t       *res;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     tp = t->tfs_peer;
     res = (ngx_http_tfs_status_msg_t *) tp->body_buffer.pos;

--- a/src/ngx_http_tfs_raw_fsname.c
+++ b/src/ngx_http_tfs_raw_fsname.c
@@ -8,7 +8,7 @@
 
 #define NGX_HTTP_TFS_KEY_MASK_LEN  10     /* strlen(NGX_HTTP_TFS_KEY_MASK) */
 
-static const u_char* NGX_HTTP_TFS_KEY_MASK = (u_char *)"Taobao-inc";
+static const u_char* NGX_HTTP_TFS_KEY_MASK = (u_char *) "Taobao-inc";
 
 static const u_char enc_table[] = "0JoU8EaN3xf19hIS2d.6p"
     "ZRFBYurMDGw7K5m4CyXsbQjg_vTOAkcHVtzqWilnLPe";
@@ -40,7 +40,7 @@ ngx_int_t
 ngx_http_tfs_raw_fsname_parse(ngx_str_t *tfs_name, ngx_str_t *suffix,
     ngx_http_tfs_raw_fsname_t* fsname)
 {
-    ngx_uint_t            suffix_len;
+    ngx_uint_t  suffix_len;
 
     if (fsname != NULL && tfs_name->data != NULL && tfs_name->data[0] != '\0') {
         ngx_memzero(fsname, sizeof(ngx_http_tfs_raw_fsname_t));
@@ -89,7 +89,8 @@ ngx_http_tfs_raw_fsname_get_name(ngx_http_tfs_raw_fsname_t* fsname,
     unsigned large_flag, ngx_int_t simple_name)
 {
     if (fsname != NULL) {
-        if (simple_name) {  // zero suffix
+        if (simple_name) {
+            /* zero suffix */
             fsname->file.suffix = 0;
         }
 
@@ -135,9 +136,9 @@ ngx_http_tfs_raw_fsname_check_file_type(ngx_str_t *tfs_name)
 void
 ngx_http_tfs_raw_fsname_encode(u_char *input, u_char *output)
 {
-    u_char               buffer[NGX_HTTP_TFS_FILE_NAME_EXCEPT_SUFFIX_LEN];
-    uint32_t             value;
-    ngx_uint_t           i, k;
+    u_char      buffer[NGX_HTTP_TFS_FILE_NAME_EXCEPT_SUFFIX_LEN];
+    uint32_t    value;
+    ngx_uint_t  i, k;
 
     k = 0;
 
@@ -158,9 +159,9 @@ ngx_http_tfs_raw_fsname_encode(u_char *input, u_char *output)
 void
 ngx_http_tfs_raw_fsname_decode(u_char *input, u_char *output)
 {
-    u_char               buffer[NGX_HTTP_TFS_FILE_NAME_EXCEPT_SUFFIX_LEN];
-    uint32_t             value;
-    ngx_uint_t           i, k;
+    u_char      buffer[NGX_HTTP_TFS_FILE_NAME_EXCEPT_SUFFIX_LEN];
+    uint32_t    value;
+    ngx_uint_t  i, k;
 
     k = 0;
 

--- a/src/ngx_http_tfs_raw_fsname.h
+++ b/src/ngx_http_tfs_raw_fsname.h
@@ -13,8 +13,7 @@
 #include <ngx_tfs_common.h>
 
 
-typedef enum
-{
+typedef enum {
     NGX_HTTP_TFS_INVALID_FILE_TYPE = 0,
     NGX_HTTP_TFS_SMALL_FILE_TYPE,
     NGX_HTTP_TFS_LARGE_FILE_TYPE
@@ -29,22 +28,22 @@ typedef struct {
 
 
 typedef struct {
-    u_char                           file_name[NGX_HTTP_TFS_FILE_NAME_BUFF_LEN];
+    u_char                         file_name[NGX_HTTP_TFS_FILE_NAME_BUFF_LEN];
 
     ngx_http_tfs_raw_fsname_filebits_t  file;
 
-    uint32_t                            cluster_id;
-    ngx_http_tfs_raw_file_type_e        file_type;
+    uint32_t                       cluster_id;
+    ngx_http_tfs_raw_file_type_e   file_type;
 } ngx_http_tfs_raw_fsname_t;
 
 
-#define ngx_http_tfs_raw_fsname_set_suffix(fsname, fs_suffix) do {         \
+#define ngx_http_tfs_raw_fsname_set_suffix(fsname, fs_suffix) do {      \
         if ((fs_suffix != NULL)                                         \
              && (fs_suffix->data != NULL)                               \
              && (fs_suffix->len != 0))                                  \
         {                                                               \
-            fsname->file.suffix = ngx_http_tfs_raw_fsname_hash(fs_suffix->data, \
-                                                               fs_suffix->len); \
+            fsname->file.suffix = ngx_http_tfs_raw_fsname_hash(         \
+                fs_suffix->data, fs_suffix->len);                       \
         }                                                               \
     } while(0)
 
@@ -58,7 +57,7 @@ typedef struct {
     ((((uint64_t)(fsname.file.suffix)) << 32) | fsname.file.seq_id)
 
 
-#define ngx_http_tfs_group_seq_match(block_id, group_count, group_seq)    \
+#define ngx_http_tfs_group_seq_match(block_id, group_count, group_seq)  \
     ((block_id % group_count) == (ngx_uint_t) group_seq)
 
 

--- a/src/ngx_http_tfs_rc_server_info.c
+++ b/src/ngx_http_tfs_rc_server_info.c
@@ -15,10 +15,10 @@ ngx_http_tfs_rcs_info_t *
 ngx_http_tfs_rcs_lookup(ngx_http_request_t *r, ngx_http_tfs_rc_ctx_t *ctx,
     ngx_str_t appkey)
 {
-    ngx_int_t                        rc;
-    ngx_uint_t                       hash;
-    ngx_rbtree_node_t               *node, *sentinel;
-    ngx_http_tfs_rcs_info_t         *tr;
+    ngx_int_t                 rc;
+    ngx_uint_t                hash;
+    ngx_rbtree_node_t        *node, *sentinel;
+    ngx_http_tfs_rcs_info_t  *tr;
 
     node = ctx->sh->rbtree.root;
     sentinel = ctx->sh->rbtree.sentinel;
@@ -61,14 +61,14 @@ void
 ngx_http_tfs_rc_server_destroy_node(ngx_http_tfs_rc_ctx_t *rc_ctx,
     ngx_http_tfs_rcs_info_t *rc_info_node)
 {
-    ngx_str_t                                *block_cache_info;
-    ngx_uint_t                                i, j;
-    ngx_rbtree_node_t                        *node;
-    ngx_http_tfs_group_info_t                *group_info;
-    ngx_http_tfs_logical_cluster_t           *logical_cluster;
-    ngx_http_tfs_physical_cluster_t          *physical_cluster;
-    ngx_http_tfs_cluster_group_info_t        *cluster_group_info;
-    ngx_http_tfs_tair_server_addr_info_t     *dup_server_info;
+    ngx_str_t                            *block_cache_info;
+    ngx_uint_t                            i, j;
+    ngx_rbtree_node_t                    *node;
+    ngx_http_tfs_group_info_t            *group_info;
+    ngx_http_tfs_logical_cluster_t       *logical_cluster;
+    ngx_http_tfs_physical_cluster_t      *physical_cluster;
+    ngx_http_tfs_cluster_group_info_t    *cluster_group_info;
+    ngx_http_tfs_tair_server_addr_info_t *dup_server_info;
 
     if (rc_info_node == NULL) {
         return;
@@ -165,9 +165,9 @@ last_free:
 void
 ngx_http_tfs_rc_server_expire(ngx_http_tfs_rc_ctx_t *ctx)
 {
-    ngx_queue_t                *q, *kp_q;
-    ngx_rbtree_node_t          *node;
-    ngx_http_tfs_rcs_info_t    *rc_info_node;
+    ngx_queue_t             *q, *kp_q;
+    ngx_rbtree_node_t       *node;
+    ngx_http_tfs_rcs_info_t *rc_info_node;
 
     if (ngx_queue_empty(&ctx->sh->queue)) {
         return;
@@ -193,10 +193,10 @@ ngx_http_tfs_rc_server_expire(ngx_http_tfs_rc_ctx_t *ctx)
 ngx_int_t
 ngx_http_tfs_rc_server_init_zone(ngx_shm_zone_t *shm_zone, void *data)
 {
-    ngx_http_tfs_rc_ctx_t            *octx = data;
+    ngx_http_tfs_rc_ctx_t  *octx = data;
 
-    size_t                            len;
-    ngx_http_tfs_rc_ctx_t            *ctx;
+    size_t                 len;
+    ngx_http_tfs_rc_ctx_t *ctx;
 
     ctx = shm_zone->data;
 
@@ -246,9 +246,9 @@ static void
 ngx_http_tfs_rcs_rbtree_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel)
 {
-    ngx_int_t                    rc;
-    ngx_rbtree_node_t          **p;
-    ngx_http_tfs_rcs_info_t     *trn, *trnt;
+    ngx_int_t                 rc;
+    ngx_rbtree_node_t       **p;
+    ngx_http_tfs_rcs_info_t  *trn, *trnt;
 
     for ( ;; ) {
 
@@ -297,9 +297,9 @@ void
 ngx_http_tfs_rcs_set_group_info_by_addr(ngx_http_tfs_rcs_info_t *rc_info,
     ngx_int_t group_count, ngx_int_t group_seq, ngx_http_tfs_inet_t addr)
 {
-    ngx_uint_t                            i, j;
-    ngx_http_tfs_group_info_t            *group_info;
-    ngx_http_tfs_cluster_group_info_t    *cluster_group_info;
+    ngx_uint_t                          i, j;
+    ngx_http_tfs_group_info_t          *group_info;
+    ngx_http_tfs_cluster_group_info_t  *cluster_group_info;
 
     cluster_group_info = rc_info->unlink_clusters;
 

--- a/src/ngx_http_tfs_rc_server_info.h
+++ b/src/ngx_http_tfs_rc_server_info.h
@@ -49,54 +49,56 @@ typedef struct {
 
 
 typedef struct {
-    uint8_t                                need_duplicate;
-    uint32_t                               dup_server_addr_hash;
-    ngx_http_tfs_tair_server_addr_info_t   dup_server_info;
+    uint8_t                      need_duplicate;
+    uint32_t                     dup_server_addr_hash;
+    ngx_http_tfs_tair_server_addr_info_t dup_server_info;
 
     /* for read and write */
-    uint32_t                               rw_cluster_count;
-    ngx_http_tfs_physical_cluster_t        rw_clusters[NGX_HTTP_TFS_MAX_CLUSTER_COUNT];
+    uint32_t                     rw_cluster_count;
+    ngx_http_tfs_physical_cluster_t rw_clusters[NGX_HTTP_TFS_MAX_CLUSTER_COUNT];
 } ngx_http_tfs_logical_cluster_t;
 
 
 typedef struct {
-    u_char                             color;
-    u_char                             dummy;
-    ngx_queue_t                        queue;
-    /* for keep alive, fixed sequence */
-    ngx_queue_t                        kp_queue;
+    u_char                       color;
+    u_char                       dummy;
+    ngx_queue_t                  queue;
 
-    ngx_str_t                          appkey;
-    uint64_t                           app_id;
-    ngx_str_t                          session_id;
-    uint32_t                           rc_servers_count;
-    uint64_t                          *rc_servers;
+    /* for keep alive, fixed sequence */
+    ngx_queue_t                  kp_queue;
+
+    ngx_str_t                    appkey;
+    uint64_t                     app_id;
+    ngx_str_t                    session_id;
+    uint32_t                     rc_servers_count;
+    uint64_t                    *rc_servers;
 
     /* logical cluster */
-    uint32_t                           logical_cluster_count;
-    ngx_http_tfs_logical_cluster_t     logical_clusters[NGX_HTTP_TFS_MAX_CLUSTER_COUNT];
+    uint32_t                     logical_cluster_count;
+    ngx_http_tfs_logical_cluster_t logical_clusters[NGX_HTTP_TFS_MAX_CLUSTER_COUNT];
 
-    uint8_t                            need_duplicate;
+    uint8_t                      need_duplicate;
 
-    uint32_t                           report_interval;
-    uint64_t                           modify_time;
-    uint64_t                           meta_root_server;
-    ngx_str_t                          remote_block_cache_info;
+    uint32_t                     report_interval;
+    uint64_t                     modify_time;
+    uint64_t                     meta_root_server;
+    ngx_str_t                    remote_block_cache_info;
 
     /* for unlink & update */
-    uint8_t                            unlink_cluster_count;
-    ngx_http_tfs_cluster_group_info_t  unlink_clusters[NGX_HTTP_TFS_MAX_CLUSTER_COUNT];
+    uint8_t                      unlink_cluster_count;
+    ngx_http_tfs_cluster_group_info_t unlink_clusters[NGX_HTTP_TFS_MAX_CLUSTER_COUNT];
 
-    uint32_t                               use_remote_block_cache;
+    uint32_t                     use_remote_block_cache;
 } ngx_http_tfs_rcs_info_t;
 
 
 typedef struct {
-    ngx_rbtree_t                  rbtree;
-    ngx_rbtree_node_t             sentinel;
-    ngx_queue_t                   queue;
+    ngx_rbtree_t                 rbtree;
+    ngx_rbtree_node_t            sentinel;
+    ngx_queue_t                  queue;
+
     /* for keep alive, fixed sequence */
-    ngx_queue_t                   kp_queue;
+    ngx_queue_t                  kp_queue;
 } ngx_http_tfs_rc_shctx_t;
 
 

--- a/src/ngx_http_tfs_rc_server_message.c
+++ b/src/ngx_http_tfs_rc_server_message.c
@@ -14,6 +14,7 @@
         }                                               \
     } while(0)
 
+
 static ngx_chain_t *ngx_http_tfs_create_login_message(ngx_http_tfs_t *t);
 static ngx_chain_t * ngx_http_tfs_create_keepalive_message(ngx_http_tfs_t *t);
 
@@ -39,7 +40,7 @@ static ngx_int_t ngx_http_tfs_parse_session_id(ngx_str_t *session_id,
 ngx_chain_t *
 ngx_http_tfs_rc_server_create_message(ngx_http_tfs_t *t)
 {
-    uint16_t                                   msg_type;
+    uint16_t  msg_type;
 
     msg_type = t->r_ctx.action.code;
 
@@ -58,6 +59,7 @@ ngx_http_tfs_rc_server_parse_message(ngx_http_tfs_t *t)
     if (t->r_ctx.action.code == NGX_HTTP_TFS_ACTION_KEEPALIVE) {
         return ngx_http_tfs_parse_keepalive_message(t);
     }
+
     return ngx_http_tfs_parse_login_message(t);
 }
 
@@ -65,10 +67,10 @@ ngx_http_tfs_rc_server_parse_message(ngx_http_tfs_t *t)
 ngx_chain_t *
 ngx_http_tfs_create_login_message(ngx_http_tfs_t *t)
 {
-    ngx_buf_t                                 *b;
-    ngx_chain_t                               *cl;
-    struct sockaddr_in                        *addr;
-    ngx_http_tfs_rcs_login_msg_header_t       *req;
+    ngx_buf_t                            *b;
+    ngx_chain_t                          *cl;
+    struct sockaddr_in                   *addr;
+    ngx_http_tfs_rcs_login_msg_header_t  *req;
 
     b = ngx_create_temp_buf(t->pool,
                             sizeof(ngx_http_tfs_rcs_login_msg_header_t)
@@ -119,14 +121,14 @@ ngx_http_tfs_create_login_message(ngx_http_tfs_t *t)
 ngx_chain_t *
 ngx_http_tfs_create_keepalive_message(ngx_http_tfs_t *t)
 {
-    u_char                         *p;
-    ssize_t                         size, base_size;
-    ngx_buf_t                      *b;
-    ngx_queue_t                    *q, *queue;
-    ngx_chain_t                    *cl, **ll;
-    ngx_http_tfs_rc_ctx_t          *rc_ctx;
-    ngx_http_tfs_header_t          *header;
-    ngx_http_tfs_rcs_info_t        *rc_info;
+    u_char                   *p;
+    ssize_t                   size, base_size;
+    ngx_buf_t                *b;
+    ngx_queue_t              *q, *queue;
+    ngx_chain_t              *cl, **ll;
+    ngx_http_tfs_rc_ctx_t    *rc_ctx;
+    ngx_http_tfs_header_t    *header;
+    ngx_http_tfs_rcs_info_t  *rc_info;
 
     rc_ctx = t->loc_conf->upstream->rc_ctx;
     ll = NULL;
@@ -234,13 +236,13 @@ keepalive_create_error:
 ngx_int_t
 ngx_http_tfs_parse_login_message(ngx_http_tfs_t *t)
 {
-    uint16_t                                  type;
-    ngx_str_t                                 err_msg;
-    ngx_int_t                                 rc;
-    ngx_http_tfs_header_t                    *header;
-    ngx_http_tfs_rc_ctx_t                    *rc_ctx;
-    ngx_http_tfs_rcs_info_t                  *rc_info;
-    ngx_http_tfs_peer_connection_t           *tp;
+    uint16_t                         type;
+    ngx_str_t                        err_msg;
+    ngx_int_t                        rc;
+    ngx_http_tfs_header_t           *header;
+    ngx_http_tfs_rc_ctx_t           *rc_ctx;
+    ngx_http_tfs_rcs_info_t         *rc_info;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     header = (ngx_http_tfs_header_t *) t->header;
     tp = t->tfs_peer;
@@ -283,16 +285,16 @@ ngx_http_tfs_parse_login_message(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_parse_keepalive_message(ngx_http_tfs_t *t)
 {
-    u_char                             *p, update;
-    uint16_t                            type;
-    ngx_str_t                           err_msg;
-    ngx_int_t                           rc;
-    ngx_queue_t                        *q, *queue;
-    ngx_rbtree_node_t                  *node;
-    ngx_http_tfs_header_t              *header;
-    ngx_http_tfs_rc_ctx_t              *rc_ctx;
-    ngx_http_tfs_rcs_info_t            *rc_info;
-    ngx_http_tfs_peer_connection_t     *tp;
+    u_char                          *p, update;
+    uint16_t                         type;
+    ngx_str_t                        err_msg;
+    ngx_int_t                        rc;
+    ngx_queue_t                     *q, *queue;
+    ngx_rbtree_node_t               *node;
+    ngx_http_tfs_header_t           *header;
+    ngx_http_tfs_rc_ctx_t           *rc_ctx;
+    ngx_http_tfs_rcs_info_t         *rc_info;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     header = (ngx_http_tfs_header_t *) t->header;
     tp = t->tfs_peer;
@@ -365,17 +367,17 @@ static ngx_int_t
 ngx_http_tfs_parse_rc_info(ngx_http_tfs_rcs_info_t *rc_info_node,
     ngx_http_tfs_rc_ctx_t *rc_ctx,  u_char *data)
 {
-    u_char                                   *p;
-    uint8_t                                   is_master;
-    uint32_t                                  cluster_id, cluster_id_len, len;
-    ngx_int_t                                 dup_info_size, rc;
-    ngx_uint_t                                i, j;
-    ngx_http_tfs_group_info_t                *group_info;
-    ngx_http_tfs_logical_cluster_t           *logical_cluster;
-    ngx_http_tfs_physical_cluster_t          *physical_cluster;
-    ngx_http_tfs_cluster_group_info_t        *cluster_group_info;
-    ngx_http_tfs_cluster_group_info_t        *cluster_group_info2;
-    ngx_http_tfs_tair_server_addr_info_t     *dup_server_info;
+    u_char                                *p;
+    uint8_t                                is_master;
+    uint32_t                               cluster_id, cluster_id_len, len;
+    ngx_int_t                              dup_info_size, rc;
+    ngx_uint_t                             i, j;
+    ngx_http_tfs_group_info_t             *group_info;
+    ngx_http_tfs_logical_cluster_t        *logical_cluster;
+    ngx_http_tfs_physical_cluster_t       *physical_cluster;
+    ngx_http_tfs_cluster_group_info_t     *cluster_group_info;
+    ngx_http_tfs_cluster_group_info_t     *cluster_group_info2;
+    ngx_http_tfs_tair_server_addr_info_t  *dup_server_info;
 
     p = data;
 
@@ -466,9 +468,9 @@ ngx_http_tfs_parse_rc_info(ngx_http_tfs_rcs_info_t *rc_info_node,
             }
             ngx_memcpy(physical_cluster->cluster_id_text.data, p,
                        physical_cluster->cluster_id_text.len);
-            p += physical_cluster->cluster_id_text.len + 1;
             /* this cluster id need get from ns */
             physical_cluster->cluster_id = 0;
+            p += physical_cluster->cluster_id_text.len + 1;
 
             /* name server vip */
             len = *((uint32_t *) p);
@@ -610,14 +612,14 @@ static ngx_int_t
 ngx_http_tfs_update_info_node(ngx_http_tfs_t *t, ngx_http_tfs_rc_ctx_t *rc_ctx,
     ngx_http_tfs_rcs_info_t *rc_info_node, u_char *base_info)
 {
-    u_char                                   *p;
-    ngx_int_t                                 rc;
-    ngx_uint_t                                i, j;
-    ngx_http_tfs_group_info_t                *group_info;
-    ngx_http_tfs_logical_cluster_t           *logical_cluster;
-    ngx_http_tfs_physical_cluster_t          *physical_cluster;
-    ngx_http_tfs_cluster_group_info_t        *cluster_group_info;
-    ngx_http_tfs_tair_server_addr_info_t     *dup_server_info;
+    u_char                                *p;
+    ngx_int_t                              rc;
+    ngx_uint_t                             i, j;
+    ngx_http_tfs_group_info_t             *group_info;
+    ngx_http_tfs_logical_cluster_t        *logical_cluster;
+    ngx_http_tfs_physical_cluster_t       *physical_cluster;
+    ngx_http_tfs_cluster_group_info_t     *cluster_group_info;
+    ngx_http_tfs_tair_server_addr_info_t  *dup_server_info;
 
     p = base_info;
 
@@ -721,12 +723,12 @@ ngx_http_tfs_create_info_node(ngx_http_tfs_t *t,
     ngx_http_tfs_rc_ctx_t *rc_ctx,
     u_char *data, ngx_str_t appkey)
 {
-    u_char                                   *p;
-    size_t                                    n;
-    uint32_t                                  len;
-    ngx_int_t                                 rc;
-    ngx_rbtree_node_t                        *node;
-    ngx_http_tfs_rcs_info_t                  *rc_info_node;
+    u_char                   *p;
+    size_t                    n;
+    uint32_t                  len;
+    ngx_int_t                 rc;
+    ngx_rbtree_node_t        *node;
+    ngx_http_tfs_rcs_info_t  *rc_info_node;
 
     rc_info_node = NULL;
 

--- a/src/ngx_http_tfs_remote_block_cache.c
+++ b/src/ngx_http_tfs_remote_block_cache.c
@@ -23,8 +23,8 @@ ngx_http_tfs_remote_block_cache_lookup(
     ngx_http_tfs_remote_block_cache_ctx_t *ctx,
     ngx_pool_t *pool, ngx_log_t *log, ngx_http_tfs_block_cache_key_t* key)
 {
-    ngx_int_t                         rc;
-    ngx_http_tair_data_t              tair_key;
+    ngx_int_t             rc;
+    ngx_http_tair_data_t  tair_key;
 
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
                    "lookup remote block cache, ns addr: %uL, block id: %uD",
@@ -49,14 +49,14 @@ static void
 ngx_http_tfs_remote_block_cache_get_handler(ngx_http_tair_key_value_t *kv,
     ngx_int_t rc, void *data)
 {
-    u_char                                  *p, *q;
+    u_char                                 *p, *q;
     uint32_t                                ds_count;
-    ngx_http_tfs_t                          *t;
-    ngx_http_tfs_inet_t                     *addr;
-    ngx_http_tfs_segment_data_t             *segment_data;
-    ngx_http_tfs_block_cache_key_t           key;
-    ngx_http_tfs_block_cache_value_t         value;
-    ngx_http_tfs_remote_block_cache_ctx_t   *ctx = data;
+    ngx_http_tfs_t                         *t;
+    ngx_http_tfs_inet_t                    *addr;
+    ngx_http_tfs_segment_data_t            *segment_data;
+    ngx_http_tfs_block_cache_key_t          key;
+    ngx_http_tfs_block_cache_value_t        value;
+    ngx_http_tfs_remote_block_cache_ctx_t  *ctx = data;
 
     t = ctx->data;
     segment_data = &t->file.segment_data[t->file.segment_index];
@@ -102,7 +102,6 @@ ngx_http_tfs_remote_block_cache_get_handler(ngx_http_tair_key_value_t *kv,
                 t->state += 1;
 
                 segment_data->cache_hit = NGX_HTTP_TFS_REMOTE_BLOCK_CACHE;
-                segment_data->block_info_src = NGX_HTTP_TFS_FROM_CACHE;
 
                 /* select data server */
                 addr = ngx_http_tfs_select_data_server(t, segment_data);
@@ -137,10 +136,9 @@ ngx_http_tfs_remote_block_cache_insert(
     ngx_http_tfs_block_cache_key_t *key,
     ngx_http_tfs_block_cache_value_t *value)
 {
-    ngx_int_t                         rc;
-    ngx_pool_t                       *tmp_pool;
-    ngx_http_tair_data_t              tair_key;
-    ngx_http_tair_data_t              tair_value;
+    ngx_int_t             rc;
+    ngx_pool_t           *tmp_pool;
+    ngx_http_tair_data_t  tair_key, tair_value;
 
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
                    "insert remote block cache, "
@@ -163,7 +161,8 @@ ngx_http_tfs_remote_block_cache_insert(
     tair_value.type = NGX_HTTP_TAIR_INT;
 
     /* since we do not care returns,
-     * we make a tmp pool and destroy it in callback */
+     * we make a tmp pool and destroy it in callback
+     */
     tmp_pool = ngx_create_pool(4096, log);
     if (tmp_pool == NULL) {
         return NGX_ERROR;
@@ -184,10 +183,7 @@ ngx_http_tfs_remote_block_cache_insert(
 static void
 ngx_http_tfs_remote_block_cache_dummy_handler(ngx_int_t rc, void *data)
 {
-    ngx_pool_t          *pool = (ngx_pool_t *)data;
-    ngx_destroy_pool(pool);
-
-    return;
+    ngx_destroy_pool((ngx_pool_t *)data);
 }
 
 
@@ -196,10 +192,10 @@ ngx_http_tfs_remote_block_cache_remove(
     ngx_http_tfs_remote_block_cache_ctx_t *ctx,
     ngx_pool_t *pool, ngx_log_t *log, ngx_http_tfs_block_cache_key_t* key)
 {
-    ngx_int_t                         rc;
-    ngx_pool_t                       *tmp_pool;
-    ngx_array_t                       tair_keys;
-    ngx_http_tair_data_t             *tair_key;
+    ngx_int_t              rc;
+    ngx_pool_t            *tmp_pool;
+    ngx_array_t            tair_keys;
+    ngx_http_tair_data_t  *tair_key;
 
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
                    "remove remote block cache, ns addr: %uL, block id: %uD",
@@ -216,7 +212,8 @@ ngx_http_tfs_remote_block_cache_remove(
     tair_key->len = NGX_HTTP_TFS_BLOCK_CACHE_KEY_SIZE;
 
     /* since we do not care returns,
-     * we make a tmp pool and destroy it in callback */
+     * we make a tmp pool and destroy it in callback
+     */
     tmp_pool = ngx_create_pool(4096, log);
     if (tmp_pool == NULL) {
         return;
@@ -237,11 +234,11 @@ ngx_http_tfs_remote_block_cache_batch_lookup(
     ngx_http_tfs_remote_block_cache_ctx_t *ctx,
     ngx_pool_t *pool, ngx_log_t *log, ngx_array_t* keys)
 {
-    ngx_int_t                         rc;
-    ngx_uint_t                        i;
-    ngx_array_t                      *tair_kvs;
-    ngx_http_tair_key_value_t        *tair_kv;
-    ngx_http_tfs_block_cache_key_t   *key;
+    ngx_int_t                        rc;
+    ngx_uint_t                       i;
+    ngx_array_t                     *tair_kvs;
+    ngx_http_tair_key_value_t       *tair_kv;
+    ngx_http_tfs_block_cache_key_t  *key;
 
     tair_kvs = ngx_array_create(pool, keys->nelts,
                                 sizeof(ngx_http_tair_key_value_t));
@@ -280,22 +277,22 @@ static void
 ngx_http_tfs_remote_block_cache_mget_handler(ngx_array_t *kvs, ngx_int_t rc,
     void *data)
 {
-    u_char                                   *p, *q;
-    uint32_t                                  ds_count, block_count;
-    ngx_uint_t                                i, j, hit_count;
-    ngx_http_tfs_t                           *t;
-    ngx_http_tair_key_value_t                *kv;
-    ngx_http_tfs_segment_data_t              *segment_data;
-    ngx_http_tfs_block_cache_key_t            key;
-    ngx_http_tfs_block_cache_value_t          value;
-    ngx_http_tfs_remote_block_cache_ctx_t    *ctx = data;
+    u_char                                 *p, *q;
+    uint32_t                                ds_count, block_count;
+    ngx_uint_t                              i, j, hit_count;
+    ngx_http_tfs_t                         *t;
+    ngx_http_tair_key_value_t              *kv;
+    ngx_http_tfs_segment_data_t            *segment_data;
+    ngx_http_tfs_block_cache_key_t          key;
+    ngx_http_tfs_block_cache_value_t        value;
+    ngx_http_tfs_remote_block_cache_ctx_t  *ctx = data;
 
     t = ctx->data;
 
     segment_data = &t->file.segment_data[t->file.segment_index];
     block_count = t->file.segment_count - t->file.segment_index;
-    if (block_count > NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT) {
-        block_count = NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT;
+    if (block_count > NGX_HTTP_TFS_MAX_BATCH_COUNT) {
+        block_count = NGX_HTTP_TFS_MAX_BATCH_COUNT;
     }
 
     if (rc == NGX_OK) {
@@ -378,22 +375,18 @@ ngx_http_tfs_remote_block_cache_mget_handler(ngx_array_t *kvs, ngx_int_t rc,
 
             if (hit_count == kvs->nelts) {
                 /* all cache hit, start batch process */
-                rc = ngx_http_tfs_batch_process_start(t);
-                if (rc == NGX_ERROR) {
-                    ngx_http_tfs_finalize_request(t->data, t,
-                                                NGX_HTTP_INTERNAL_SERVER_ERROR);
-                    return;
-                }
-                return;
+                t->decline_handler = ngx_http_tfs_batch_process_start;
+                rc = NGX_DECLINED;
             }
         }
 
     } else {
+        rc = NGX_OK;
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, t->log, 0,
                        "remote block cache miss");
     }
 
-    ngx_http_tfs_finalize_state(t, NGX_OK);
+    ngx_http_tfs_finalize_state(t, rc);
 }
 
 
@@ -403,15 +396,14 @@ ngx_http_tfs_get_remote_block_cache_instance(
     ngx_http_tfs_remote_block_cache_ctx_t *ctx,
     ngx_str_t *server_addr)
 {
-    size_t                                 server_addr_len;
-    uint32_t                               server_addr_hash;
-    ngx_int_t                              rc, i;
-    ngx_str_t                             *st;
-    ngx_array_t                            config_server;
-    ngx_http_tfs_t                        *t;
-    ngx_http_tfs_tair_instance_t          *instance;
-    ngx_http_etair_server_conf_t          *server;
-    ngx_http_tfs_tair_server_addr_info_t   server_addr_info;
+    size_t                                server_addr_len;
+    uint32_t                              server_addr_hash;
+    ngx_int_t                             rc, i;
+    ngx_str_t                            *st, *group_name;
+    ngx_array_t                           config_server;
+    ngx_http_tfs_t                       *t;
+    ngx_http_tfs_tair_instance_t         *instance;
+    ngx_http_tfs_tair_server_addr_info_t  server_addr_info;
 
     if (server_addr->len == 0
         || server_addr->data == NULL)
@@ -456,8 +448,8 @@ ngx_http_tfs_get_remote_block_cache_instance(
         }
     }
 
-    server = &server_addr_info.server[NGX_HTTP_TFS_TAIR_CONFIG_SERVER_COUNT];
-    instance->server = ngx_http_etair_create_server(server,
+    group_name = &server_addr_info.server[NGX_HTTP_TFS_TAIR_CONFIG_SERVER_COUNT];
+    instance->server = ngx_http_etair_create_server(group_name,
                                                     &config_server,
                                                     t->main_conf->tair_timeout,
                                                     (ngx_cycle_t *) ngx_cycle);

--- a/src/ngx_http_tfs_restful.h
+++ b/src/ngx_http_tfs_restful.h
@@ -39,11 +39,11 @@ typedef struct {
     ngx_int_t                    write_meta_segment;
     ngx_int_t                    no_dedup;
     ngx_int_t                    chk_file_hole;
+    ngx_int_t                    recursive;
 
     unsigned                     meta:1;
     unsigned                     get_appid:1;
     unsigned                     chk_exist:1;
-    unsigned                     recursive:1;
 } ngx_http_tfs_restful_ctx_t;
 
 

--- a/src/ngx_http_tfs_root_server_message.c
+++ b/src/ngx_http_tfs_root_server_message.c
@@ -11,9 +11,9 @@
 ngx_chain_t *
 ngx_http_tfs_root_server_create_message(ngx_pool_t *pool)
 {
-    ngx_buf_t                                 *b;
-    ngx_chain_t                               *cl;
-    ngx_http_tfs_rs_request_t                 *req;
+    ngx_buf_t                  *b;
+    ngx_chain_t                *cl;
+    ngx_http_tfs_rs_request_t  *req;
 
     b = ngx_create_temp_buf(pool, sizeof(ngx_http_tfs_rs_request_t));
     if (b == NULL) {
@@ -47,10 +47,10 @@ ngx_http_tfs_root_server_create_message(ngx_pool_t *pool)
 ngx_int_t
 ngx_http_tfs_root_server_parse_message(ngx_http_tfs_t *t)
 {
-    ngx_int_t                                 rc;
-    ngx_http_tfs_peer_connection_t           *tp;
-    ngx_http_tfs_rs_response_t               *resp;
-    uLongf                                    table_length;
+    uLongf                           table_length;
+    ngx_int_t                        rc;
+    ngx_http_tfs_rs_response_t      *resp;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     tp = t->tfs_peer;
     resp = (ngx_http_tfs_rs_response_t *) (tp->body_buffer.pos);

--- a/src/ngx_http_tfs_server_handler.c
+++ b/src/ngx_http_tfs_server_handler.c
@@ -18,7 +18,7 @@
 ngx_int_t
 ngx_http_tfs_create_rs_request(ngx_http_tfs_t *t)
 {
-    ngx_chain_t                              *cl;
+    ngx_chain_t  *cl;
 
     cl = ngx_http_tfs_root_server_create_message(t->pool);
     if (cl == NULL) {
@@ -34,11 +34,11 @@ ngx_http_tfs_create_rs_request(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_process_rs(ngx_http_tfs_t *t)
 {
-    ngx_int_t                                 rc;
-    ngx_buf_t                                *b;
-    ngx_http_tfs_inet_t                      *addr;
-    ngx_http_tfs_header_t                    *header;
-    ngx_http_tfs_peer_connection_t           *tp;
+    ngx_int_t                        rc;
+    ngx_buf_t                       *b;
+    ngx_http_tfs_inet_t             *addr;
+    ngx_http_tfs_header_t           *header;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     header = (ngx_http_tfs_header_t *) t->header;
     tp = t->tfs_peer;
@@ -85,13 +85,13 @@ ngx_http_tfs_create_ms_request(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_process_ms(ngx_http_tfs_t *t)
 {
-    ngx_buf_t                                *b;
-    ngx_int_t                                 rc, dir_levels, parent_dir_len;
-    ngx_chain_t                              *cl, **ll;
-    ngx_http_tfs_header_t                    *header;
-    ngx_http_tfs_peer_connection_t           *tp;
-    ngx_http_tfs_logical_cluster_t           *logical_cluster;
-    ngx_http_tfs_physical_cluster_t          *physical_cluster;
+    ngx_buf_t                        *b;
+    ngx_int_t                         rc, dir_levels, parent_dir_len;
+    ngx_chain_t                      *cl, **ll;
+    ngx_http_tfs_header_t            *header;
+    ngx_http_tfs_peer_connection_t   *tp;
+    ngx_http_tfs_logical_cluster_t   *logical_cluster;
+    ngx_http_tfs_physical_cluster_t  *physical_cluster;
 
     header = (ngx_http_tfs_header_t *) t->header;
     tp = t->tfs_peer;
@@ -142,7 +142,6 @@ ngx_http_tfs_process_ms(ngx_http_tfs_t *t)
                 }
                 t->last_dir_level = 0;
                 t->dir_lens[0] = t->last_file_path.len;
-                t->orig_action = t->r_ctx.action.code;
 
             } else {
                 parent_dir_len = ngx_http_tfs_get_parent_dir(&t->last_file_path,
@@ -151,6 +150,7 @@ ngx_http_tfs_process_ms(ngx_http_tfs_t *t)
             t->last_dir_level++;
             t->dir_lens[t->last_dir_level] = parent_dir_len;
             t->last_file_path.len = t->dir_lens[t->last_dir_level];
+            t->orig_action = t->r_ctx.action.code;
             /* temporarily modify */
             t->r_ctx.action.code = NGX_HTTP_TFS_ACTION_CREATE_DIR;
             return NGX_OK;
@@ -158,7 +158,8 @@ ngx_http_tfs_process_ms(ngx_http_tfs_t *t)
     }
 
     /* parent dir may be created by others
-     * during the recursive creating process */
+     * during the recursive creating process
+     */
     if (rc == NGX_HTTP_TFS_EXIT_TARGET_EXIST_ERROR && t->last_dir_level > 0) {
         rc = NGX_OK;
     }
@@ -324,29 +325,8 @@ ngx_http_tfs_process_ms(ngx_http_tfs_t *t)
             /* lookup block cache */
             t->block_cache_ctx.curr_lookup_cache =
                 NGX_HTTP_TFS_LOCAL_BLOCK_CACHE;
-            rc = ngx_http_tfs_batch_lookup_block_cache(t);
-            /* local cache all hit */
-            if (rc == NGX_OK) {
-                rc = ngx_http_tfs_batch_process_start(t);
-                if (rc == NGX_ERROR) {
-                    return NGX_ERROR;
-                }
-                return NGX_DECLINED;
-            }
-
-            /* remote cache handler will deal */
-            if (rc == NGX_DECLINED
-                && (t->block_cache_ctx.use_cache
-                    & NGX_HTTP_TFS_REMOTE_BLOCK_CACHE))
-            {
-                return NGX_DECLINED;
-            }
-
-            /* block cache should not affect, go for ns */
-            if (rc == NGX_ERROR) {
-                ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                              "batch lookup block cache failed.");
-            }
+            t->decline_handler = ngx_http_tfs_batch_lookup_block_cache;
+            return NGX_DECLINED;
         }
 
         return NGX_OK;
@@ -359,13 +339,13 @@ ngx_http_tfs_process_ms(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_process_ms_ls_dir(ngx_http_tfs_t *t)
 {
-    ngx_buf_t                                *b;
-    ngx_int_t                                 rc;
-    ngx_chain_t                              *cl, **ll;
-    ngx_http_tfs_ms_ls_response_t            *fake_rsp;
-    ngx_http_tfs_peer_connection_t           *tps;
-    ngx_http_tfs_peer_connection_t           *tp;
-    ngx_http_tfs_custom_meta_info_t          *meta_info;
+    ngx_buf_t                        *b;
+    ngx_int_t                         rc;
+    ngx_chain_t                      *cl, **ll;
+    ngx_http_tfs_ms_ls_response_t    *fake_rsp;
+    ngx_http_tfs_peer_connection_t   *tps;
+    ngx_http_tfs_peer_connection_t   *tp;
+    ngx_http_tfs_custom_meta_info_t  *meta_info;
 
     tp = t->tfs_peer;
     b = &tp->body_buffer;
@@ -457,7 +437,7 @@ ngx_http_tfs_process_ms_ls_dir(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_create_rcs_request(ngx_http_tfs_t *t)
 {
-    ngx_chain_t                              *cl;
+    ngx_chain_t  *cl;
 
     cl = ngx_http_tfs_rc_server_create_message(t);
     if (cl == NULL) {
@@ -473,11 +453,11 @@ ngx_http_tfs_create_rcs_request(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_process_rcs(ngx_http_tfs_t *t)
 {
-    ngx_buf_t                               *b;
-    ngx_int_t                                rc;
-    ngx_http_tfs_rc_ctx_t                   *rc_ctx;
-    ngx_http_tfs_rcs_info_t                 *rc_info;
-    ngx_http_tfs_peer_connection_t          *tp;
+    ngx_buf_t                       *b;
+    ngx_int_t                        rc;
+    ngx_http_tfs_rc_ctx_t           *rc_ctx;
+    ngx_http_tfs_rcs_info_t         *rc_info;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     tp = t->tfs_peer;
     b = &tp->body_buffer;
@@ -510,10 +490,8 @@ ngx_http_tfs_process_rcs(ngx_http_tfs_t *t)
         return NGX_DONE;
     }
 
-    // TODO: use fine granularity mutex(per rc_info_node mutex)
-    //ngx_shmtx_lock(&rc_ctx->shpool->mutex);
+    /* TODO: use fine granularity mutex(per rc_info_node mutex) */
     rc = ngx_http_tfs_misc_ctx_init(t, rc_info);
-    //ngx_shmtx_unlock(&rc_ctx->shpool->mutex);
 
     return rc;
 }
@@ -538,16 +516,16 @@ ngx_http_tfs_create_ns_request(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_process_ns(ngx_http_tfs_t *t)
 {
-    uint32_t                                  curr_block_id, cluster_id;
-    ngx_buf_t                                *b;
-    ngx_int_t                                 rc;
-    ngx_str_t                                *cluster_id_text;
-    ngx_http_tfs_inet_t                      *addr;
-    ngx_http_tfs_header_t                    *header;
-    ngx_http_tfs_rcs_info_t                  *rc_info;
-    ngx_http_tfs_peer_connection_t           *tp;
-    ngx_http_tfs_logical_cluster_t           *logical_cluster;
-    ngx_http_tfs_physical_cluster_t          *physical_cluster;
+    uint32_t                          cluster_id;
+    ngx_buf_t                        *b;
+    ngx_int_t                         rc;
+    ngx_str_t                        *cluster_id_text;
+    ngx_http_tfs_inet_t              *addr;
+    ngx_http_tfs_header_t            *header;
+    ngx_http_tfs_rcs_info_t          *rc_info;
+    ngx_http_tfs_peer_connection_t   *tp;
+    ngx_http_tfs_logical_cluster_t   *logical_cluster;
+    ngx_http_tfs_physical_cluster_t  *physical_cluster;
 
     header = (ngx_http_tfs_header_t *) t->header;
     tp = t->tfs_peer;
@@ -577,10 +555,7 @@ ngx_http_tfs_process_ns(ngx_http_tfs_t *t)
             && (t->r_ctx.version == 2
                 || (t->is_large_file && !t->is_process_meta_seg)))
         {
-            rc = ngx_http_tfs_batch_process_start(t);
-            if (rc == NGX_ERROR) {
-                return NGX_ERROR;
-            }
+            t->decline_handler = ngx_http_tfs_batch_process_start;
             return NGX_DECLINED;
         }
         t->state = NGX_HTTP_TFS_STATE_READ_READ_DATA;
@@ -623,10 +598,7 @@ ngx_http_tfs_process_ns(ngx_http_tfs_t *t)
                     && (t->r_ctx.version == 2
                         || (t->is_large_file && !t->is_process_meta_seg)))
                 {
-                    rc = ngx_http_tfs_batch_process_start(t);
-                    if (rc == NGX_ERROR) {
-                        return NGX_ERROR;
-                    }
+                    t->decline_handler = ngx_http_tfs_batch_process_start;
                     return NGX_DECLINED;
                 }
                 t->state = NGX_HTTP_TFS_STATE_WRITE_CREATE_FILE_NAME;
@@ -638,98 +610,30 @@ ngx_http_tfs_process_ns(ngx_http_tfs_t *t)
         switch (t->state) {
         case NGX_HTTP_TFS_STATE_REMOVE_GET_GROUP_COUNT:
             /* maybe able to make choice */
-            if (t->group_count == 1) {
-                rc_info = t->rc_info_node;
-
-                ngx_http_tfs_rcs_set_group_info_by_addr(rc_info,
-                                                        t->group_count, 0,
-                                                        t->name_server_addr);
-
-                rc = ngx_http_tfs_select_name_server(t, rc_info,
-                                                     &t->name_server_addr,
-                                                     &t->name_server_addr_text);
-                if (rc == NGX_ERROR) {
-                    /* in order to return 404 */
-                    return NGX_HTTP_TFS_EIXT_SERVER_OBJECT_NOT_FOUND;
-                }
-
-                tp->peer.free(&tp->peer, tp->peer.data, 0);
-
-                ngx_http_tfs_peer_set_addr(t->pool,
-                                 &t->tfs_peer_servers[NGX_HTTP_TFS_NAME_SERVER],
-                                 &t->name_server_addr);
-
-            } else {
+            if (t->group_count != 1) {
                 t->state = NGX_HTTP_TFS_STATE_REMOVE_GET_GROUP_SEQ;
             }
-
-            return rc;
+            /* group_count == 1, maybe able to make choice */
+            t->group_seq = 0;
         case NGX_HTTP_TFS_STATE_REMOVE_GET_GROUP_SEQ:
             rc_info = t->rc_info_node;
-
             ngx_http_tfs_rcs_set_group_info_by_addr(rc_info,
                                                     t->group_count,
                                                     t->group_seq,
                                                     t->name_server_addr);
-
-            if (t->r_ctx.version == 1) {
-                curr_block_id = t->r_ctx.fsname.file.block_id;
-
-            } else {
-                curr_block_id = t->file.segment_data[0].segment_info.block_id;
+            rc = ngx_http_tfs_select_name_server(t, rc_info,
+                                                 &t->name_server_addr,
+                                                 &t->name_server_addr_text);
+            if (rc == NGX_ERROR) {
+                /* in order to return 404 */
+                return NGX_HTTP_TFS_EIXT_SERVER_OBJECT_NOT_FOUND;
             }
 
-            if (ngx_http_tfs_group_seq_match(curr_block_id,
-                                             t->group_count, t->group_seq))
-            {
-                ngx_log_debug1(NGX_LOG_DEBUG_HTTP, t->log, 0,
-                               "unlink, select nameserver: %V",
-                               &t->name_server_addr_text);
-                t->state = NGX_HTTP_TFS_STATE_REMOVE_GET_BLK_INFO;
-                /* find out which logical cluster this addr belongs to
-                   so that we can use the right de-dup addr */
-                t->logical_cluster_index = 0;
-                for ( ;
-                     t->logical_cluster_index < rc_info->logical_cluster_count;
-                     t->logical_cluster_index++)
-                {
-                    logical_cluster =
-                        &rc_info->logical_clusters[t->logical_cluster_index];
-                    t->rw_cluster_index = 0;
-                    for ( ;
-                         t->rw_cluster_index
-                              < logical_cluster->rw_cluster_count;
-                         t->rw_cluster_index++)
-                    {
-                        physical_cluster =
-                            &logical_cluster->rw_clusters[t->rw_cluster_index];
-                        if (*(uint64_t*)(&physical_cluster->ns_vip)
-                            == *(uint64_t*)(&t->name_server_addr))
-                        {
-                            return rc;
-                        }
-                    }
-                }
-                ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                              "can not find logical cluster index of ns: %V",
-                              &t->name_server_addr_text);
-                return NGX_ERROR;
+            tp->peer.free(&tp->peer, tp->peer.data, 0);
 
-            } else {
-                rc = ngx_http_tfs_select_name_server(t, rc_info,
-                                                     &t->name_server_addr,
-                                                     &t->name_server_addr_text);
-                if (rc == NGX_ERROR) {
-                    /* in order to return 404 */
-                    return NGX_HTTP_TFS_EIXT_SERVER_OBJECT_NOT_FOUND;
-                }
-
-                tp->peer.free(&tp->peer, tp->peer.data, 0);
-
-                ngx_http_tfs_peer_set_addr(t->pool,
-                                 &t->tfs_peer_servers[NGX_HTTP_TFS_NAME_SERVER],
-                                 &t->name_server_addr);
-            }
+            ngx_http_tfs_peer_set_addr(t->pool,
+                             &t->tfs_peer_servers[NGX_HTTP_TFS_NAME_SERVER],
+                             &t->name_server_addr);
             return rc;
         case NGX_HTTP_TFS_STATE_REMOVE_GET_BLK_INFO:
             if (t->is_large_file
@@ -764,21 +668,21 @@ ngx_http_tfs_process_ns(ngx_http_tfs_t *t)
 void
 ngx_http_tfs_reset_segment_data(ngx_http_tfs_t *t)
 {
-    uint32_t                        block_count, i;
-    ngx_http_tfs_segment_data_t    *segment_data;
+    uint32_t                      block_count, i;
+    ngx_http_tfs_segment_data_t  *segment_data;
 
     /* reset current lookup cache */
     t->block_cache_ctx.curr_lookup_cache = NGX_HTTP_TFS_LOCAL_BLOCK_CACHE;
 
     block_count = t->file.segment_count - t->file.segment_index;
-    if (block_count > NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT) {
-        block_count = NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT;
+    if (block_count > NGX_HTTP_TFS_MAX_BATCH_COUNT) {
+        block_count = NGX_HTTP_TFS_MAX_BATCH_COUNT;
     }
 
     segment_data = &t->file.segment_data[t->file.segment_index];
     for (i = 0; i < block_count; i++, segment_data++) {
         segment_data->cache_hit = NGX_HTTP_TFS_NO_BLOCK_CACHE;
-        segment_data->block_info_src = NGX_HTTP_TFS_FROM_NONE;
+        segment_data->block_info_src = NGX_HTTP_TFS_FROM_CACHE;
         segment_data->block_info.ds_addrs = NULL;
         segment_data->ds_retry = 0;
         segment_data->ds_index = 0;
@@ -789,8 +693,8 @@ ngx_http_tfs_reset_segment_data(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_retry_ns(ngx_http_tfs_t *t)
 {
-    ngx_int_t                                 rc;
-    ngx_http_tfs_peer_connection_t           *tp;
+    ngx_int_t                        rc;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     if (!t->retry_curr_ns) {
         t->rw_cluster_index++;
@@ -825,43 +729,12 @@ ngx_http_tfs_retry_ns(ngx_http_tfs_t *t)
                 && (t->r_ctx.version == 2
                     || (t->is_large_file && !t->is_process_meta_seg)))
             {
-                rc = ngx_http_tfs_batch_lookup_block_cache(t);
-                /* local cache all hit */
-                if (rc == NGX_OK) {
-                    rc = ngx_http_tfs_batch_process_start(t);
-                    if (rc == NGX_ERROR) {
-                        return NGX_ERROR;
-                    }
-                    return NGX_DECLINED;
-                }
+                t->decline_handler = ngx_http_tfs_batch_lookup_block_cache;
 
             } else {
-                rc = ngx_http_tfs_lookup_block_cache(t,
-                                  &t->file.segment_data[t->file.segment_index]);
+                t->decline_handler = ngx_http_tfs_lookup_block_cache;
             }
-
-            /* block cache should not affect, go for ns */
-            if (rc == NGX_ERROR) {
-                ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                              "lookup block cache failed.");
-            }
-
-            /* remote cache handler will deal */
-            if (rc == NGX_DECLINED
-                && (t->block_cache_ctx.use_cache
-                    & NGX_HTTP_TFS_REMOTE_BLOCK_CACHE))
-            {
-                return NGX_OK;
-            }
-
-            /* cache hit, turn to ds */
-            t->tfs_peer = ngx_http_tfs_select_peer(t);
-            if (t->tfs_peer == NULL) {
-                return NGX_ERROR;
-            }
-
-            t->recv_chain->buf = &t->header_buffer;
-            t->recv_chain->next->buf = &t->tfs_peer->body_buffer;
+            return t->decline_handler(t);
         }
         break;
     case NGX_HTTP_TFS_ACTION_WRITE_FILE:
@@ -888,7 +761,7 @@ ngx_http_tfs_retry_ns(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_create_ds_request(ngx_http_tfs_t *t)
 {
-    ngx_chain_t                              *cl;
+    ngx_chain_t  *cl;
 
     cl = ngx_http_tfs_data_server_create_message(t);
     if (cl == NULL) {
@@ -904,15 +777,15 @@ ngx_http_tfs_create_ds_request(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_process_ds(ngx_http_tfs_t *t)
 {
-    size_t                                    b_size;
-    uint32_t                                  body_len, len_to_update;
-    ngx_int_t                                 rc;
-    ngx_buf_t                                *b, *body_buffer;
-    ngx_chain_t                              *cl, **ll;
-    ngx_http_request_t                       *r;
-    ngx_http_tfs_header_t                    *header;
-    ngx_http_tfs_segment_data_t              *segment_data;
-    ngx_http_tfs_peer_connection_t           *tp;
+    size_t                           b_size;
+    uint32_t                         body_len, len_to_update;
+    ngx_int_t                        rc;
+    ngx_buf_t                       *b, *body_buffer;
+    ngx_chain_t                     *cl, **ll;
+    ngx_http_request_t              *r;
+    ngx_http_tfs_header_t           *header;
+    ngx_http_tfs_segment_data_t     *segment_data;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     header = (ngx_http_tfs_header_t *) t->header;
     tp = t->tfs_peer;
@@ -974,27 +847,11 @@ ngx_http_tfs_process_ds(ngx_http_tfs_t *t)
                     if (rc == NGX_ERROR) {
                         return NGX_ERROR;
                     }
-                    t->dedup_ctx.file_ref_count += 1;
                     r = t->data;
-                    rc = ngx_http_tfs_set_duplicate_info(&t->dedup_ctx,
-                                                         t->pool,
-                                                         t->log,
-                                                         r->request_body->bufs);
-                    /* stat success and file status normal,
-                     * but save tair failed need save new tfs file,
-                     * but do not save tair */
-                    if (rc == NGX_ERROR) {
-                        t->state = NGX_HTTP_TFS_STATE_WRITE_CLUSTER_ID_NS;
-                        t->is_stat_dup_file = NGX_HTTP_TFS_NO;
-                        t->use_dedup = NGX_HTTP_TFS_NO;
-                        /* need reset output buf */
-                        t->out_bufs = NULL;
-                        /* need reset block id and file id */
-                        t->file.segment_data[0].segment_info.block_id = 0;
-                        t->file.segment_data[0].segment_info.file_id = 0;
-                        return NGX_OK;
-                    }
-                    return rc;
+                    t->dedup_ctx.file_data = r->request_body->bufs;
+                    t->dedup_ctx.file_ref_count += 1;
+                    t->decline_handler = ngx_http_tfs_set_duplicate_info;
+                    return NGX_DECLINED;
                 }
 
             } else {
@@ -1027,7 +884,7 @@ ngx_http_tfs_process_ds(ngx_http_tfs_t *t)
                 return rc;
             }
 
-            /* write success, update data buf and offset */
+            /* write success, update data buf, offset and crc */
             cl = segment_data->data;
             len_to_update = segment_data->oper_size;
             while (len_to_update > 0) {
@@ -1056,6 +913,7 @@ ngx_http_tfs_process_ds(ngx_http_tfs_t *t)
             segment_data->oper_offset += segment_data->oper_size;
             segment_data->oper_size = ngx_min(t->file.left_length,
                                               NGX_HTTP_TFS_MAX_FRAGMENT_SIZE);
+            segment_data->segment_info.crc = segment_data->curr_crc;
 
             if (t->r_ctx.version == 1) {
                 if (t->file.left_length > 0 && !t->is_large_file) {
@@ -1085,18 +943,14 @@ ngx_http_tfs_process_ds(ngx_http_tfs_t *t)
                     return NGX_ERROR;
                 }
                 /* when new tfs file is saved,
-                 * do not care saving tair is success or not */
+                 * do not care saving tair is success or not
+                 */
                 if (t->use_dedup) {
-                    t->dedup_ctx.file_ref_count += 1;
                     r = t->data;
-                    rc = ngx_http_tfs_set_duplicate_info(&t->dedup_ctx,
-                                                         t->pool,
-                                                         t->log,
-                                                         r->request_body->bufs);
-                    if (rc == NGX_ERROR) {
-                        return NGX_DONE;
-                    }
-                    return rc;
+                    t->dedup_ctx.file_data = r->request_body->bufs;
+                    t->dedup_ctx.file_ref_count += 1;
+                    t->decline_handler = ngx_http_tfs_set_duplicate_info;
+                    return NGX_DECLINED;
                 }
                 return NGX_DONE;
             }
@@ -1173,9 +1027,9 @@ ngx_http_tfs_process_ds(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_retry_ds(ngx_http_tfs_t *t)
 {
-    ngx_http_tfs_inet_t                 *addr;
-    ngx_http_tfs_segment_data_t         *segment_data;
-    ngx_http_tfs_peer_connection_t      *tp;
+    ngx_http_tfs_inet_t             *addr;
+    ngx_http_tfs_segment_data_t     *segment_data;
+    ngx_http_tfs_peer_connection_t  *tp;
 
     tp = t->tfs_peer;
     tp->peer.free(&tp->peer, tp->peer.data, 0);
@@ -1194,11 +1048,13 @@ ngx_http_tfs_retry_ds(ngx_http_tfs_t *t)
             if (t->is_large_file && t->is_process_meta_seg) {
                 return NGX_HTTP_TFS_EIXT_SERVER_OBJECT_NOT_FOUND;
             }
-            // TODO: dedup
+
+            /* TODO: dedup */
             return NGX_ERROR;
         case NGX_HTTP_TFS_ACTION_WRITE_FILE:
             /* stat retry_ds failed, do not dedup,
-             * save new tfs file and do not save tair */
+             * save new tfs file and do not save tair
+             */
             if (t->is_stat_dup_file) {
                 t->is_stat_dup_file = NGX_HTTP_TFS_NO;
                 t->use_dedup = NGX_HTTP_TFS_NO;
@@ -1247,12 +1103,12 @@ ngx_http_tfs_retry_ds(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_process_ds_read(ngx_http_tfs_t *t)
 {
-    size_t                                    size;
-    ngx_int_t                                 rc;
-    ngx_buf_t                                *b;
-    ngx_http_tfs_segment_data_t              *segment_data;
-    ngx_http_tfs_peer_connection_t           *tp;
-    ngx_http_tfs_logical_cluster_t           *logical_cluster;
+    size_t                           size;
+    ngx_int_t                        rc;
+    ngx_buf_t                       *b;
+    ngx_http_tfs_segment_data_t     *segment_data;
+    ngx_http_tfs_peer_connection_t  *tp;
+    ngx_http_tfs_logical_cluster_t  *logical_cluster;
 
     tp = t->tfs_peer;
     b = &tp->body_buffer;
@@ -1264,7 +1120,8 @@ ngx_http_tfs_process_ds_read(ngx_http_tfs_t *t)
     }
 
     rc = ngx_http_tfs_data_server_parse_message(t);
-    if (rc == NGX_ERROR) {
+    if (rc == NGX_ERROR || rc == NGX_HTTP_TFS_AGAIN) {
+        ngx_http_tfs_clear_buf(b);
         return NGX_ERROR;
     }
 
@@ -1307,30 +1164,8 @@ ngx_http_tfs_process_ds_read(ngx_http_tfs_t *t)
 
                     t->block_cache_ctx.curr_lookup_cache =
                                                  NGX_HTTP_TFS_LOCAL_BLOCK_CACHE;
-                    rc = ngx_http_tfs_batch_lookup_block_cache(t);
-                    if (rc == NGX_OK) {
-                        /* local cache all hit */
-                        rc = ngx_http_tfs_batch_process_start(t);
-                        if (rc == NGX_ERROR) {
-                            return NGX_ERROR;
-                        }
-                        rc = NGX_DECLINED;
-
-                    } else if (rc == NGX_DECLINED) {
-                        /* local cache has miss, go for ns */
-                        if (!(t->block_cache_ctx.use_cache
-                              & NGX_HTTP_TFS_REMOTE_BLOCK_CACHE))
-                        {
-                            rc = NGX_OK;
-                        }
-
-                    } else if (rc == NGX_ERROR) {
-                        /* block cache should not affect, go for ns */
-                        ngx_log_error(NGX_LOG_ERR, t->log, 0,
-                                      "batch lookup block cache failed.");
-                        rc = NGX_OK;
-                    }
-                    return rc;
+                    t->decline_handler = ngx_http_tfs_batch_lookup_block_cache;
+                    return NGX_DECLINED;
                 }
 
                 /* sub process also return here */
@@ -1370,7 +1205,8 @@ ngx_http_tfs_process_ds_read(ngx_http_tfs_t *t)
                         ngx_log_error(NGX_LOG_ERR, t->log, 0,
                                       "get dedup instance failed.");
                         /* get dedup instance fail, do not unlink file,
-                         * return success */
+                         * return success
+                         */
                         t->state = NGX_HTTP_TFS_STATE_REMOVE_DONE;
                         return NGX_DONE;
                     }
@@ -1378,17 +1214,9 @@ ngx_http_tfs_process_ds_read(ngx_http_tfs_t *t)
                     /* reset buf pos to get whole file data */
                     t->meta_segment_data->buf->pos =
                                                t->meta_segment_data->buf->start;
-                    rc = ngx_http_tfs_get_duplicate_info(&t->dedup_ctx,
-                                                         t->pool,
-                                                         t->log,
-                                                         t->meta_segment_data);
-                    /* get dup info from tair failed,
-                     * do not unlink file, return success */
-                    if (rc == NGX_ERROR) {
-                        t->state = NGX_HTTP_TFS_STATE_REMOVE_DONE;
-                        return NGX_DONE;
-                    }
-                    return rc;
+                    t->dedup_ctx.file_data = t->meta_segment_data;
+                    t->decline_handler = ngx_http_tfs_get_duplicate_info;
+                    return NGX_DECLINED;
                 }
                 if (t->is_large_file) {
                     rc = ngx_http_tfs_get_segment_for_delete(t);
@@ -1416,58 +1244,66 @@ ngx_http_tfs_process_ds_read(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_process_ds_input_filter(ngx_http_tfs_t *t)
 {
-    uint32_t                                  body_len;
-    ngx_http_tfs_segment_data_t              *segment_data;
-    ngx_http_tfs_peer_connection_t           *tp;
-    ngx_http_tfs_ds_read_response_t          *msg;
+    int16_t                           msg_type;
+    uint32_t                          body_len;
+    ngx_http_tfs_segment_data_t      *segment_data;
+    ngx_http_tfs_peer_connection_t   *tp;
+    ngx_http_tfs_ds_read_response_t  *resp;
 
     tp = t->tfs_peer;
-    msg = (ngx_http_tfs_ds_read_response_t *) t->header;
+    resp = (ngx_http_tfs_ds_read_response_t *) t->header;
+    msg_type = resp->header.type;
+    if (msg_type == NGX_HTTP_TFS_STATUS_MESSAGE) {
+        t->length = resp->header.len - sizeof(uint32_t);
+        return NGX_OK;
+    }
+
     segment_data = &t->file.segment_data[t->file.segment_index];
-    if (msg->data_len < 0) {
-        if (msg->data_len == NGX_HTTP_TFS_EXIT_NO_LOGICBLOCK_ERROR) {
+    if (resp->data_len < 0) {
+        if (resp->data_len == NGX_HTTP_TFS_EXIT_NO_LOGICBLOCK_ERROR) {
             ngx_http_tfs_remove_block_cache(t, segment_data);
 
-        } else if (msg->data_len == -22) {
+        } else if (resp->data_len == -22) {
             /* for compatibility,
-             * old dataserver will return this instead of -1007 */
-            msg->data_len = NGX_HTTP_TFS_EXIT_INVALID_ARGU_ERROR;
+             * old dataserver will return this instead of -1007
+             */
+            resp->data_len = NGX_HTTP_TFS_EXIT_INVALID_ARGU_ERROR;
         }
 
         /* must be bad request, do not retry */
-        if (msg->data_len == NGX_HTTP_TFS_EXIT_READ_OFFSET_ERROR
-            || msg->data_len == NGX_HTTP_TFS_EXIT_INVALID_ARGU_ERROR
-            || msg->data_len == NGX_HTTP_TFS_EXIT_PHYSIC_BLOCK_OFFSET_ERROR)
+        if (resp->data_len == NGX_HTTP_TFS_EXIT_READ_OFFSET_ERROR
+            || resp->data_len == NGX_HTTP_TFS_EXIT_INVALID_ARGU_ERROR
+            || resp->data_len == NGX_HTTP_TFS_EXIT_PHYSIC_BLOCK_OFFSET_ERROR)
         {
-            return msg->data_len;
+            return resp->data_len;
         }
         ngx_log_error(NGX_LOG_ERR, t->log, 0,
                       "read file(block id: %uD, file id: %uL) "
                       "from (%s) fail, error code: %D, will retry",
                       segment_data->segment_info.block_id,
                       segment_data->segment_info.file_id,
-                      tp->peer_addr_text, msg->data_len);
+                      tp->peer_addr_text, resp->data_len);
         return NGX_HTTP_TFS_AGAIN;
     }
 
-    if (msg->data_len == 0) {
+    if (resp->data_len == 0) {
         t->state = NGX_HTTP_TFS_STATE_READ_DONE;
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, t->log, 0, "read len is 0");
         return NGX_DONE;
     }
 
-    body_len = msg->header.len - sizeof(uint32_t);
+    body_len = resp->header.len - sizeof(uint32_t);
     t->length = body_len;
-    /* in readv2, body_len = msg->data_len + 40 */
-    segment_data->oper_size = msg->data_len;
+    /* in readv2, body_len = resp->data_len + 40 */
+    segment_data->oper_size = resp->data_len;
     /* sub process only read once */
     if (t->parent) {
-        t->file.left_length = msg->data_len;
+        t->file.left_length = resp->data_len;
     }
 
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, t->log, 0,
                    "read len is %O, data len is %D",
-                   t->length, msg->data_len);
+                   t->length, resp->data_len);
 
     return NGX_OK;
 }
@@ -1476,7 +1312,7 @@ ngx_http_tfs_process_ds_input_filter(ngx_http_tfs_t *t)
 ngx_int_t
 ngx_http_tfs_process_ms_input_filter(ngx_http_tfs_t *t)
 {
-    ngx_http_tfs_header_t                    *header;
+    ngx_http_tfs_header_t  *header;
 
     header = (ngx_http_tfs_header_t *) t->header;
     t->length = header->len;

--- a/src/ngx_http_tfs_server_handler.h
+++ b/src/ngx_http_tfs_server_handler.h
@@ -43,5 +43,5 @@ ngx_int_t ngx_http_tfs_retry_ds(ngx_http_tfs_t *t);
 ngx_int_t ngx_http_tfs_retry_ns(ngx_http_tfs_t *t);
 
 
-#endif  /*  */
+#endif  /* _NGX_HTTP_TFS_SERVER_HANDLER_H_INCLUDED_ */
 

--- a/src/ngx_http_tfs_tair_helper.c
+++ b/src/ngx_http_tfs_tair_helper.c
@@ -15,7 +15,7 @@ ngx_http_tfs_tair_get_helper(ngx_http_tfs_tair_instance_t *instance,
     ngx_http_tair_data_t *key, ngx_http_tair_get_handler_pt callback,
     void *data)
 {
-    ngx_int_t                  rc;
+    ngx_int_t  rc;
 
     if (instance == NULL || key == NULL) {
         return NGX_ERROR;
@@ -33,10 +33,10 @@ ngx_http_tfs_tair_get_helper(ngx_http_tfs_tair_instance_t *instance,
 
 
 ngx_int_t ngx_http_tfs_tair_mget_helper(ngx_http_tfs_tair_instance_t *instance,
-    ngx_pool_t *pool, ngx_log_t *log,
-    ngx_array_t *kvs, ngx_http_tair_mget_handler_pt callback, void *data)
+    ngx_pool_t *pool, ngx_log_t *log, ngx_array_t *kvs,
+    ngx_http_tair_mget_handler_pt callback, void *data)
 {
-    ngx_int_t                                 rc;
+    ngx_int_t  rc;
 
     if (instance == NULL || kvs == NULL) {
         return NGX_ERROR;
@@ -60,14 +60,14 @@ ngx_http_tfs_tair_put_helper(ngx_http_tfs_tair_instance_t *instance,
     ngx_int_t expire, ngx_int_t version,
     ngx_http_tair_handler_pt callback, void *data)
 {
-    ngx_int_t                     rc;
+    ngx_int_t  rc;
 
     if (instance == NULL || key == NULL || value == NULL) {
         return NGX_ERROR;
     }
 
     rc = ngx_http_tair_put(instance->server, pool, log, *key,
-                           *value, instance->area, 0/*nx*/, expire,
+                           *value, instance->area, 0 /*nx*/, expire,
                            version, callback, data);
 
     if (rc != NGX_OK) {
@@ -80,10 +80,10 @@ ngx_http_tfs_tair_put_helper(ngx_http_tfs_tair_instance_t *instance,
 
 ngx_int_t
 ngx_http_tfs_tair_delete_helper(ngx_http_tfs_tair_instance_t *instance,
-    ngx_pool_t *pool, ngx_log_t *log,
-    ngx_array_t *keys, ngx_http_tair_handler_pt callback, void *data)
+    ngx_pool_t *pool, ngx_log_t *log, ngx_array_t *keys,
+    ngx_http_tair_handler_pt callback, void *data)
 {
-    ngx_int_t                                 rc;
+    ngx_int_t  rc;
 
     if (instance == NULL || keys == NULL) {
         return NGX_ERROR;
@@ -146,9 +146,9 @@ ngx_http_tfs_parse_tair_server_addr_info(
     ngx_http_tfs_tair_server_addr_info_t *info,
     u_char *addr, uint32_t len, void *pool, uint8_t shared_memory)
 {
-    u_char           *temp, *p;
-    ssize_t           info_size;
-    ngx_int_t         i;
+    u_char    *temp, *p;
+    ssize_t    info_size;
+    ngx_int_t  i;
 
     p = addr;
 

--- a/src/ngx_http_tfs_tair_helper.h
+++ b/src/ngx_http_tfs_tair_helper.h
@@ -15,10 +15,11 @@
 
 
 typedef struct {
-    uint32_t                               server_addr_hash;
-    ngx_int_t                              area;
+    uint32_t                          server_addr_hash;
+    ngx_int_t                         area;
+
 #ifdef NGX_HTTP_TFS_USE_TAIR
-    ngx_http_etair_server_conf_t          *server;
+    ngx_http_etair_server_conf_t     *server;
 #endif
 } ngx_http_tfs_tair_instance_t;
 
@@ -28,28 +29,30 @@ typedef struct {
     ngx_int_t  area;
 } ngx_http_tfs_tair_server_addr_info_t;
 
+
 #ifndef NGX_HTTP_TFS_USE_TAIR
 
 #define NGX_HTTP_TAIR_BYTEARRAY       9
 #define NGX_HTTP_TAIR_INT             1
 #define NGX_HTTP_ETAIR_SUCCESS        0
 
+
 typedef struct {
 
-    size_t          len;
-    u_char         *data;
+    size_t                            len;
+    u_char                           *data;
 
-    ngx_uint_t      type;
+    ngx_uint_t                        type;
 } ngx_http_tair_data_t;
 
 typedef struct {
-    ngx_http_tair_data_t    key;
-    ngx_http_tair_data_t   *value;
+    ngx_http_tair_data_t              key;
+    ngx_http_tair_data_t             *value;
 
-    ngx_int_t               version;
-    ngx_int_t               exptime;
+    ngx_int_t                         version;
+    ngx_int_t                         exptime;
 
-    ngx_int_t               rc;
+    ngx_int_t                         rc;
 } ngx_http_tair_key_value_t;
 
 typedef void (*ngx_http_tair_handler_pt)(ngx_int_t rc, void *data);

--- a/src/ngx_http_tfs_timers.c
+++ b/src/ngx_http_tfs_timers.c
@@ -15,10 +15,10 @@ ngx_http_tfs_timers_lock_t *
 ngx_http_tfs_timers_init(ngx_cycle_t *cycle,
     u_char *lock_file)
 {
-    u_char                       *shared;
-    size_t                        size;
-    ngx_shm_t                     shm;
-    ngx_http_tfs_timers_lock_t   *lock;
+    u_char                     *shared;
+    size_t                      size;
+    ngx_shm_t                   shm;
+    ngx_http_tfs_timers_lock_t *lock;
 
     /* cl should be equal or bigger than cache line size */
 
@@ -69,7 +69,7 @@ ngx_int_t
 ngx_http_tfs_add_rcs_timers(ngx_cycle_t *cycle,
     ngx_http_tfs_timers_data_t *data)
 {
-    ngx_event_t                      *ev;
+    ngx_event_t  *ev;
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cycle->log, 0,
                    "http check tfs rc servers");
@@ -93,8 +93,8 @@ ngx_http_tfs_add_rcs_timers(ngx_cycle_t *cycle,
 ngx_int_t
 ngx_http_tfs_timers_finalize_request_handler(ngx_http_tfs_t *t)
 {
-    ngx_event_t                   *event;
-    ngx_http_tfs_timers_data_t    *data;
+    ngx_event_t                 *event;
+    ngx_http_tfs_timers_data_t  *data;
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, t->log, 0, "http tfs timers finalize");
 
@@ -111,11 +111,11 @@ ngx_http_tfs_timers_finalize_request_handler(ngx_http_tfs_t *t)
 static void
 ngx_http_tfs_timeout_handler(ngx_event_t *event)
 {
-    ngx_int_t                         rc;
-    ngx_pool_t                       *pool;
-    ngx_http_tfs_t                   *t;
-    ngx_http_request_t               *r;
-    ngx_http_tfs_timers_data_t       *data;
+    ngx_int_t                   rc;
+    ngx_pool_t                  *pool;
+    ngx_http_tfs_t              *t;
+    ngx_http_request_t          *r;
+    ngx_http_tfs_timers_data_t  *data;
 
     data = event->data;
     if (ngx_shmtx_trylock(&data->lock->ngx_http_tfs_kp_mutex)) {

--- a/src/ngx_tfs_common.h
+++ b/src/ngx_tfs_common.h
@@ -13,7 +13,6 @@
 
 #define NGX_HTTP_TFS_HEADER                           0
 #define NGX_HTTP_TFS_BODY                             1
-#define NGX_HTTP_TFS_METASERVER_COUNT                 10240
 
 #define NGX_HTTP_TFS_YES                              1
 #define NGX_HTTP_TFS_NO                               0
@@ -31,6 +30,7 @@
 
 /* rcs, ns, ds, rs, ms */
 #define NGX_HTTP_TFS_SERVER_COUNT                     5
+#define NGX_HTTP_TFS_METASERVER_COUNT                 10240
 /* master_conifg_server;slave_config_server;group */
 #define NGX_HTTP_TFS_TAIR_SERVER_ADDR_PART_COUNT      3
 /* master && slave */
@@ -42,6 +42,7 @@
 #define NGX_HTTP_TFS_USE_LARGE_FILE_SIZE              (15 * 1024 * 1024)
 #define NGX_HTTP_TFS_MAX_SIZE                         (ULLONG_MAX - 1)
 
+#define NGX_HTTP_TFS_DEFAULT_BODY_BUFFER_SIZE         (2 * 1024 * 1024)
 #define NGX_HTTP_TFS_ZERO_BUF_SIZE                    (512 * 1024)
 #define NGX_HTTP_TFS_INIT_FILE_HOLE_COUNT             5
 
@@ -65,10 +66,10 @@
 #define NGX_HTTP_TFS_CMD_GET_GROUP_SEQ                 23
 
 #define NGX_HTTP_TFS_GMT_TIME_SIZE                  \
-    (sizeof("Mon, 28 Sep 1970 06:00:00 UTC+0800") - 1)
+    (sizeof("Mon, 28 Sep 1970 06:00:00 GMT") - 1)
 
 #define NGX_HTTP_TFS_MAX_FRAGMENT_SIZE                 (2 * 1024 * 1024)
-#define NGX_HTTP_TFS_MAX_SEND_FRAG_COUNT               8
+#define NGX_HTTP_TFS_MAX_BATCH_COUNT                   8
 
 
 #define NGX_HTTP_TFS_MUR_HASH_SEED                     97


### PR DESCRIPTION
1. fixed coding style, remove some redundant code
2. bugfix: read large/custom file timeout or core
3. bugfix: close file may failed (crc error) when retry occurs
4. bugfix: should not select data server when invalid local block hit
5. bugfix: should not return 500 when client time out
6. bugfix: should parse status msg instead of read response msg when ds can not serve
7. bugfix: modify default body buffer size for recv from upstream to 2M
8. bugfix: some wrong return code
9. bugfix: fix read corrupted large file bug
   10.new feature: add last-modified header in response if possible
